### PR TITLE
Fixed typo of champion masteries example comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ rt.block_on(async {
         .get_all_champion_masteries(PlatformRoute::NA1, &summoner.id).await
         .expect("Get champion masteries failed.");
 
-    // Print champioon masteries.
+    // Print champion masteries.
     for (i, mastery) in masteries.iter().take(10).enumerate() {
         println!("{: >2}) {: <9}    {: >7} ({})", i + 1,
             mastery.champion_id.name().unwrap_or("UNKNOWN"),


### PR DESCRIPTION
Hello! 

Its probably not important, and maybe I'm wrong and they're supposed to be there, but the two "o's" in champion bothered me