### PR TITLE
Add cloning to RiotAPI

### DIFF
--- a/riven/src/config.rs
+++ b/riven/src/config.rs
@@ -7,7 +7,7 @@ use reqwest::ClientBuilder;
 /// Configuration for instantiating RiotApi.
 ///
 ///
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RiotApiConfig {
     pub(crate) base_url: String,
     pub(crate) retries: u8,

--- a/riven/src/riot_api.rs
+++ b/riven/src/riot_api.rs
@@ -43,6 +43,7 @@ use crate::RiotApiError;
 ///
 /// To adjust rate limiting, see [RiotApiConfig] and use
 /// [`RiotApi::new(config)`](RiotApi::new) to construct an instance.
+#[derive(Clone)]
 pub struct RiotApi {
     /// Configuration settings.
     config: RiotApiConfig,

--- a/riven/src/util/insert_only_chashmap.rs
+++ b/riven/src/util/insert_only_chashmap.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 
+#[derive(Clone)]
 pub struct InsertOnlyCHashMap<K: Hash + Eq, V> {
     base: Mutex<HashMap<K, Arc<V>>>,
 }


### PR DESCRIPTION
From what I can tell the `RiotApi` struct is safe to clone because of the `Client` being a `Arc` wrapped object, and the `regional_requesters` being in a Mutex.