### PR TITLE
Add TFT queue 6000 (Set 3.5 Revival)

### DIFF
--- a/riven/src/consts/queue.rs
+++ b/riven/src/consts/queue.rs
@@ -390,5 +390,8 @@ newtype_enum! {
         /// `2020`.
         /// Tutorial 3 games on Summoner's Rift
         SUMMONERS_RIFT_TUTORIAL_3 = 2020,
+        /// `6000`.
+        /// Teamfight Tactics Set 3.5 Revival games on Convergence
+        CONVERGENCE_TEAMFIGHT_TACTICS_SET_3_5_REVIVAL = 6000,
     }
 }


### PR DESCRIPTION
I have autogenerated riven/src/consts/queue.rs but instead of using http://www.mingweisamuel.com/riotapi-schema/enums/queues.json I used my own json from MingweiSamuel/riotapi-schema#43 .