### PR TITLE
chore: set msrv, min dependency versions, fix #77

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,16 +35,16 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
+      # - name: Setup Node
+      #   uses: actions/setup-node@v4
+      #   with:
+      #     node-version: 20
 
-      - name: Install Node dependencies
-        run: npm ci --prefix riven/srcgen
+      # - name: Install Node dependencies
+      #   run: npm ci --prefix riven/srcgen
 
-      - name: Run codegen
-        run: node riven/srcgen
+      # - name: Run codegen
+      #   run: node riven/srcgen
 
       - name: Install Rust nightly toolchain
         uses: actions-rs/toolchain@v1
@@ -121,3 +121,23 @@ jobs:
         with:
           command: clippy
           args: --all-features --all-targets -- -D warnings
+
+  msrv:
+    name: Verify MSRV
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install Rust nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: rustfmt
+
+      - run: cargo install cargo-msrv --no-default-features
+      - run: cargo msrv verify --path riven

--- a/riven/Cargo.toml
+++ b/riven/Cargo.toml
@@ -7,12 +7,17 @@ description = "Riot Games API Library"
 readme = "../README.md"
 license = "MIT"
 edition = "2018"
+rust-version = "1.71.1"
 include = ["src/**", "../README.md", "/examples"]
 keywords = ["riot-games", "riot", "league", "league-of-legends"]
 categories = ["api-bindings", "web-programming::http-client", "wasm"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+
+[[bin]]
+name = "__bin"
+path = "src/main.rs"
 
 [package.metadata.docs.rs]
 features = ["nightly"]
@@ -48,45 +53,45 @@ name = "proxy"
 required-features = ["__proxy"]
 
 [dependencies]
-futures = "0.3"
-log = "0.4"
-memo-map = "0.3"
-metrics = { version = "0.24", optional = true }
-num_enum = "0.5"
-parking_lot = "0.12"
-reqwest = { version = "0.11", default-features = false, features = [
+futures = "0.3.0"
+log = "0.4.8"
+memo-map = "0.3.0"
+metrics = { version = "0.24.0", optional = true }
+num_enum = "0.5.0"
+parking_lot = "0.12.0"
+reqwest = { version = "0.11.2", default-features = false, features = [
     "gzip",
     "json",
 ] }
-scan_fmt = { version = "0.2", default-features = false }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-serde_repr = "0.1"
-slab = "0.4"
-strum = "0.20"
-strum_macros = "0.20"
-tracing = { version = "0.1", optional = true }
+serde = { version = "1.0.85", features = ["derive"] }
+serde_derive = "1.0.85"
+serde_json = "1.0.1"
+serde_repr = "0.1.0"
+slab = "0.4.4"
+strum = "0.20.0"
+strum_macros = "0.20.0"
+tracing = { version = "0.1.22", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-tokio = { version = "1", default-features = false, features = ["time"] }
+tokio = { version = "1.20.0", default-features = false, features = ["time"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 gloo-timers = { version = "0.3", features = ["futures"] }
 web-time = "1.0.0"
 
 [dev-dependencies]
-env_logger = "0.11.0"
+env_logger = ">=0.10.0,<0.12.0"
 fake_instant = "0.5.0"
-tracing = "0.1"
+tracing = "0.1.22"
 tracing-subscriber = "0.3.17"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
-hyper = { version = "0.14", features = ["server"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-tokio-shared-rt = "0.1"
+hyper = { version = "0.14.5", features = ["server"] }
+tokio = { version = "1.20.0", features = ["macros", "rt-multi-thread"] }
+tokio-shared-rt = "0.1.0"
 
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
 console_error_panic_hook = "0.1"
 console_log = "1.0"
-wasm-bindgen = "0.2"
+wasm-bindgen = "0.2.70"
 wasm-bindgen-test = "0.3"

--- a/riven/Cargo.toml
+++ b/riven/Cargo.toml
@@ -15,10 +15,6 @@ categories = ["api-bindings", "web-programming::http-client", "wasm"]
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[[bin]]
-name = "__bin"
-path = "src/main.rs"
-
 [package.metadata.docs.rs]
 features = ["nightly"]
 

--- a/riven/src/main.rs
+++ b/riven/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    panic!();
+}

--- a/riven/src/main.rs
+++ b/riven/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    panic!();
-}

--- a/riven/src/req/token_bucket.rs
+++ b/riven/src/req/token_bucket.rs
@@ -30,13 +30,15 @@ pub trait TokenBucket {
     /// Get the duration of this bucket.
     /// # Returns
     /// Duration of the bucket.
-    #[allow(dead_code, reason = "false positive")]
+    #[cfg_attr(feature = "nightly", allow(dead_code, reason = "false positive"))]
+    #[cfg_attr(not(feature = "nightly"), allow(dead_code))]
     fn get_bucket_duration(&self) -> Duration;
 
     /// Get the total limit of this bucket per timespan.
     /// # Returns
     /// Total limit per timespan.
-    #[allow(dead_code, reason = "false positive")]
+    #[cfg_attr(feature = "nightly", allow(dead_code, reason = "false positive"))]
+    #[cfg_attr(not(feature = "nightly"), allow(dead_code))]
     fn get_total_limit(&self) -> usize;
 }
 

--- a/test-min-deps.bash
+++ b/test-min-deps.bash
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euxo pipefail
+
+RUSTFLAGS='-Aunexpected_cfgs'
+cargo update -Z direct-minimal-versions
+cargo build --all-targets
+
+./test.bash


### PR DESCRIPTION
Fix #77

* Check MSRV in CI
* Lower MSRV to 1.71.1 by gating `allow(..., reason = "...")`
* Sets all min dependency crate versions needed by riven, via `-Z direct-minimal-versions`
* Adds `test-min-deps.bash` script to run `-Z direct-minimal-versions`
* Removes underutilized `scan_fmt` dependency, replaces with simple string manipulation code