### PR TITLE
feat: `eserde` feature for better maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,12 +74,12 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all-targets --features nightly,deny-unknown,__proxy
+          args: --all-targets --features nightly,deny-unknown,eserde,__proxy
 
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-fail-fast --features nightly,deny-unknown,__proxy
+          args: --no-fail-fast --features nightly,deny-unknown,eserde,__proxy
         env:
           RUST_BACKTRACE: 1
           RUST_LOG: riven=debug
@@ -89,7 +89,7 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - working-directory: riven
-        run: wasm-pack test --node -- --features nightly,deny-unknown
+        run: wasm-pack test --node -- --features nightly,deny-unknown,eserde
         env:
           RGAPI_KEY: ${{ secrets.RGAPI_KEY }}
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,7 @@
         "tracing",
         "deny-unknown",
         "eserde",
-    ]
+    ],
+    "evenBetterToml.formatter.compactArrays": false,
+    "evenBetterToml.formatter.columnWidth": 100
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
     "rust-analyzer.cargo.features": [
         "nightly",
         "tracing",
-        "deny-unknown"
+        "deny-unknown",
+        "eserde",
     ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,19 +279,20 @@ dependencies = [
 
 [[package]]
 name = "eserde"
-version = "0.1.5"
-source = "git+https://github.com/MingweiSamuel/eserde.git?branch=impl_edeserialize#7b7f1920008871fe09f3116f9bf0a40b19e7ce6f"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b00bbe58b41137cb1f1421385eae8ae360ce02722ab24dcc91a45be30daeeea"
 dependencies = [
  "eserde_derive",
  "itoa",
  "serde",
- "serde_json",
 ]
 
 [[package]]
 name = "eserde_derive"
-version = "0.1.5"
-source = "git+https://github.com/MingweiSamuel/eserde.git?branch=impl_edeserialize#7b7f1920008871fe09f3116f9bf0a40b19e7ce6f"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92f146f29032c31be76a0b0a0275a5d11b5835711db47689fe4edd3017993615"
 dependencies = [
  "indexmap",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,8 +279,8 @@ dependencies = [
 
 [[package]]
 name = "eserde"
-version = "0.1.2"
-source = "git+https://github.com/MingweiSamuel/eserde.git?branch=deserialize-with#7ca7ff6c423069ef114791824d9ff0fce59747ab"
+version = "0.1.5"
+source = "git+https://github.com/MingweiSamuel/eserde.git?branch=impl_edeserialize#7b7f1920008871fe09f3116f9bf0a40b19e7ce6f"
 dependencies = [
  "eserde_derive",
  "itoa",
@@ -290,8 +290,8 @@ dependencies = [
 
 [[package]]
 name = "eserde_derive"
-version = "0.1.2"
-source = "git+https://github.com/MingweiSamuel/eserde.git?branch=deserialize-with#7ca7ff6c423069ef114791824d9ff0fce59747ab"
+version = "0.1.5"
+source = "git+https://github.com/MingweiSamuel/eserde.git?branch=impl_edeserialize#7b7f1920008871fe09f3116f9bf0a40b19e7ce6f"
 dependencies = [
  "indexmap",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,8 +280,7 @@ dependencies = [
 [[package]]
 name = "eserde"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b385c6ce7ab3d94b5c04262aa48afcc97c2329ecb2559e83792493b5e71630"
+source = "git+https://github.com/MingweiSamuel/eserde.git?branch=deserialize-with#7ca7ff6c423069ef114791824d9ff0fce59747ab"
 dependencies = [
  "eserde_derive",
  "itoa",
@@ -292,8 +291,7 @@ dependencies = [
 [[package]]
 name = "eserde_derive"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58199fbf1f2cd20d1a1086ac6e88909493376f9bf648ac65ddda599c2b92f82a"
+source = "git+https://github.com/MingweiSamuel/eserde.git?branch=deserialize-with#7ca7ff6c423069ef114791824d9ff0fce59747ab"
 dependencies = [
  "indexmap",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "eserde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b385c6ce7ab3d94b5c04262aa48afcc97c2329ecb2559e83792493b5e71630"
+dependencies = [
+ "eserde_derive",
+ "itoa",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "eserde_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58199fbf1f2cd20d1a1086ac6e88909493376f9bf648ac65ddda599c2b92f82a"
+dependencies = [
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "fake_instant"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,6 +1170,7 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "env_logger",
+ "eserde",
  "fake_instant",
  "futures",
  "gloo-timers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,7 @@ dependencies = [
  "eserde_derive",
  "itoa",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/riven/Cargo.toml
+++ b/riven/Cargo.toml
@@ -50,7 +50,7 @@ name = "proxy"
 required-features = ["__proxy"]
 
 [dependencies]
-eserde = { optional = true, git = "https://github.com/MingweiSamuel/eserde.git", branch = "deserialize-with", features = ["json"] }
+eserde = { optional = true, git = "https://github.com/MingweiSamuel/eserde.git", branch = "impl_edeserialize", features = ["json"] }
 futures = "0.3.0"
 log = "0.4.8"
 memo-map = "0.3.0"

--- a/riven/Cargo.toml
+++ b/riven/Cargo.toml
@@ -1,64 +1,64 @@
 [package]
 name = "riven"
 version = "2.64.0"
-authors = ["Mingwei Samuel <mingwei.samuel@gmail.com>"]
+authors = [ "Mingwei Samuel <mingwei.samuel@gmail.com>" ]
 repository = "https://github.com/MingweiSamuel/Riven"
 description = "Riot Games API Library"
 readme = "../README.md"
 license = "MIT"
 edition = "2018"
 rust-version = "1.71.1"
-include = ["src/**", "../README.md", "/examples"]
-keywords = ["riot-games", "riot", "league", "league-of-legends"]
-categories = ["api-bindings", "web-programming::http-client", "wasm"]
+include = [ "src/**", "../README.md", "/examples" ]
+keywords = [ "riot-games", "riot", "league", "league-of-legends" ]
+categories = [ "api-bindings", "web-programming::http-client", "wasm" ]
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = [ "cdylib", "rlib" ]
 
 [package.metadata.docs.rs]
-features = ["nightly"]
+features = [ "nightly" ]
 
 [features]
-default = ["default-tls"]
+default = [ "default-tls" ]
 
-nightly = ["parking_lot/nightly"]
+nightly = [ "parking_lot/nightly" ]
 
-default-tls = ["reqwest/default-tls"]
-native-tls = ["reqwest/native-tls"]
-rustls-tls = ["reqwest/rustls-tls"]
+default-tls = [ "reqwest/default-tls" ]
+native-tls = [ "reqwest/native-tls" ]
+rustls-tls = [ "reqwest/rustls-tls" ]
 
-metrics = ["dep:metrics"]
-eserde = ["dep:eserde"]
+metrics = [ "dep:metrics" ]
+eserde = [ "dep:eserde" ]
 
-deny-unknown = ["deny-unknown-fields", "deny-unknown-enum-variants"]
+deny-unknown = [ "deny-unknown-fields", "deny-unknown-enum-variants" ]
 # If enabled, extra unknown fields encountered during deserialization will
 # cause an error instead of being ignored.
-deny-unknown-fields = []
+deny-unknown-fields = [  ]
 # If enabled, deserialization of unknown enum variants will cause an error
 # instead of being deserialized to `UNKNOWN` or other integer variants.
 deny-unknown-enum-variants = [
     "deny-unknown-enum-variants-strings",
     "deny-unknown-enum-variants-integers",
 ]
-deny-unknown-enum-variants-strings = []
-deny-unknown-enum-variants-integers = []
+deny-unknown-enum-variants-strings = [  ]
+deny-unknown-enum-variants-integers = [  ]
 
-__proxy = []
+__proxy = [  ]
 
 [[example]]
 name = "proxy"
-required-features = ["__proxy"]
+required-features = [ "__proxy" ]
 
 [dependencies]
-eserde = { optional = true, version = "0.1.6" }
+eserde = { optional = true, version = "0.1.6", features = [ "json" ] }
 futures = "0.3.0"
 log = "0.4.8"
 memo-map = "0.3.0"
 metrics = { optional = true, version = "0.24.0" }
 num_enum = "0.5.0"
 parking_lot = "0.12.0"
-reqwest = { version = "0.11.2", default-features = false, features = ["gzip"] }
-serde = { version = "1.0.85", features = ["derive"] }
+reqwest = { version = "0.11.2", default-features = false, features = [ "gzip" ] }
+serde = { version = "1.0.85", features = [ "derive" ] }
 serde_derive = "1.0.85"
 serde_json = "1.0.1"
 serde_repr = "0.1.0"
@@ -68,10 +68,10 @@ strum_macros = "0.20.0"
 tracing = { optional = true, version = "0.1.22" }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-tokio = { version = "1.20.0", default-features = false, features = ["time"] }
+tokio = { version = "1.20.0", default-features = false, features = [ "time" ] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-gloo-timers = { version = "0.3", features = ["futures"] }
+gloo-timers = { version = "0.3", features = [ "futures" ] }
 web-time = "1.0.0"
 
 [dev-dependencies]
@@ -81,8 +81,8 @@ tracing = "0.1.22"
 tracing-subscriber = "0.3.17"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
-hyper = { version = "0.14.5", features = ["server"] }
-tokio = { version = "1.20.0", features = ["macros", "rt-multi-thread"] }
+hyper = { version = "0.14.5", features = [ "server" ] }
+tokio = { version = "1.20.0", features = [ "macros", "rt-multi-thread" ] }
 tokio-shared-rt = "0.1.0"
 
 [target.'cfg(target_family = "wasm")'.dev-dependencies]

--- a/riven/Cargo.toml
+++ b/riven/Cargo.toml
@@ -28,6 +28,7 @@ native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
 
 metrics = ["dep:metrics"]
+eserde = ["dep:eserde"]
 
 deny-unknown = ["deny-unknown-fields", "deny-unknown-enum-variants"]
 # If enabled, extra unknown fields encountered during deserialization will
@@ -49,10 +50,11 @@ name = "proxy"
 required-features = ["__proxy"]
 
 [dependencies]
+eserde = { optional = true, version = "0.1.2", features = ["json"] }
 futures = "0.3.0"
 log = "0.4.8"
 memo-map = "0.3.0"
-metrics = { version = "0.24.0", optional = true }
+metrics = { optional = true, version = "0.24.0" }
 num_enum = "0.5.0"
 parking_lot = "0.12.0"
 reqwest = { version = "0.11.2", default-features = false, features = ["gzip"] }
@@ -63,7 +65,7 @@ serde_repr = "0.1.0"
 slab = "0.4.4"
 strum = "0.20.0"
 strum_macros = "0.20.0"
-tracing = { version = "0.1.22", optional = true }
+tracing = { optional = true, version = "0.1.22" }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 tokio = { version = "1.20.0", default-features = false, features = ["time"] }

--- a/riven/Cargo.toml
+++ b/riven/Cargo.toml
@@ -50,7 +50,7 @@ name = "proxy"
 required-features = ["__proxy"]
 
 [dependencies]
-eserde = { optional = true, version = "0.1.2", features = ["json"] }
+eserde = { optional = true, git = "https://github.com/MingweiSamuel/eserde.git", branch = "deserialize-with", features = ["json"] }
 futures = "0.3.0"
 log = "0.4.8"
 memo-map = "0.3.0"

--- a/riven/Cargo.toml
+++ b/riven/Cargo.toml
@@ -50,7 +50,7 @@ name = "proxy"
 required-features = ["__proxy"]
 
 [dependencies]
-eserde = { optional = true, git = "https://github.com/MingweiSamuel/eserde.git", branch = "impl_edeserialize", features = ["json"] }
+eserde = { optional = true, version = "0.1.6" }
 futures = "0.3.0"
 log = "0.4.8"
 memo-map = "0.3.0"

--- a/riven/Cargo.toml
+++ b/riven/Cargo.toml
@@ -55,10 +55,7 @@ memo-map = "0.3.0"
 metrics = { version = "0.24.0", optional = true }
 num_enum = "0.5.0"
 parking_lot = "0.12.0"
-reqwest = { version = "0.11.2", default-features = false, features = [
-    "gzip",
-    "json",
-] }
+reqwest = { version = "0.11.2", default-features = false, features = ["gzip"] }
 serde = { version = "1.0.85", features = ["derive"] }
 serde_derive = "1.0.85"
 serde_json = "1.0.1"

--- a/riven/examples/proxy/main.rs
+++ b/riven/examples/proxy/main.rs
@@ -84,7 +84,7 @@ async fn handle_request(req: Request<Body>) -> Result<Response<Body>, Infallible
         .await;
     let resp_info = match resp_result {
         Err(err) => {
-            log::info!("Riot API error: {:#?}", err.source_reqwest_error());
+            log::info!("Riot API error: {}", err);
             return Ok(create_json_response(
                 r#"{"error":"Riot API request failed."}"#,
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/riven/src/consts/division.rs
+++ b/riven/src/consts/division.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::upper_case_acronyms)]
+
 use std::cmp::Ordering;
 
 use num_enum::{IntoPrimitive, TryFromPrimitive};

--- a/riven/src/consts/division.rs
+++ b/riven/src/consts/division.rs
@@ -1,9 +1,10 @@
 use std::cmp::Ordering;
 
 use num_enum::{IntoPrimitive, TryFromPrimitive};
-use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use strum_macros::{AsRefStr, Display, EnumString, IntoStaticStr};
+
+use crate::{Deserialize, Serialize};
 
 /// LoL and TFT rank divisions, I, II, III, IV, and (deprecated) V.
 ///

--- a/riven/src/consts/division.rs
+++ b/riven/src/consts/division.rs
@@ -4,8 +4,6 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 use strum::IntoEnumIterator;
 use strum_macros::{AsRefStr, Display, EnumString, IntoStaticStr};
 
-use crate::{Deserialize, Serialize};
-
 /// LoL and TFT rank divisions, I, II, III, IV, and (deprecated) V.
 ///
 /// Ordered such that "higher" divisions are greater than "lower" ones: `Division::I > Division::IV`.
@@ -26,8 +24,8 @@ use crate::{Deserialize, Serialize};
     IntoStaticStr,
     IntoPrimitive,
     TryFromPrimitive,
-    Serialize,
-    Deserialize,
+    serde::Serialize,
+    crate::de::Deserialize,
 )]
 #[repr(u8)]
 pub enum Division {

--- a/riven/src/consts/game_type.rs
+++ b/riven/src/consts/game_type.rs
@@ -7,14 +7,13 @@
 //                                           //
 ///////////////////////////////////////////////
 
-use serde::{ Serialize, Deserialize };
 use strum_macros::{ EnumString, Display, AsRefStr, IntoStaticStr };
 
 /// League of Legends game type: matched game, custom game, or tutorial game.
 #[derive(Debug, Copy, Clone)]
 #[derive(Eq, PartialEq, Hash)]
 #[derive(EnumString, Display, AsRefStr, IntoStaticStr)]
-#[derive(Serialize, Deserialize)]
+#[derive(crate::Serialize, crate::Deserialize)]
 #[repr(u8)]
 pub enum GameType {
     /// Custom games

--- a/riven/src/consts/game_type.rs
+++ b/riven/src/consts/game_type.rs
@@ -13,7 +13,7 @@ use strum_macros::{ EnumString, Display, AsRefStr, IntoStaticStr };
 #[derive(Debug, Copy, Clone)]
 #[derive(Eq, PartialEq, Hash)]
 #[derive(EnumString, Display, AsRefStr, IntoStaticStr)]
-#[derive(crate::Serialize, crate::Deserialize)]
+#[derive(serde::Serialize, crate::de::Deserialize)]
 #[repr(u8)]
 pub enum GameType {
     /// Custom games

--- a/riven/src/consts/macros.rs
+++ b/riven/src/consts/macros.rs
@@ -65,6 +65,7 @@ macro_rules! serde_strum_unknown {
                 }
             }
         }
+        impl_edeserialize!($name);
     };
 }
 
@@ -172,6 +173,7 @@ macro_rules! newtype_enum {
                 }
             }
         }
+        impl_edeserialize!($name);
 
         impl std::fmt::Display for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -184,4 +186,22 @@ macro_rules! newtype_enum {
             }
         }
     }
+}
+
+macro_rules! impl_edeserialize {
+    ($($t:ty),* $(,)?) => {
+        $(
+            #[cfg(feature = "eserde")]
+            impl<'de> eserde::EDeserialize<'de> for $t {
+                fn deserialize_for_errors<D>(deserializer: D) -> Result<(), ()>
+                where
+                    D: serde::Deserializer<'de>
+                {
+                    <Self as serde::de::Deserialize<'de>>::deserialize(deserializer).map(|_| ()).map_err(|e| {
+                        eserde::reporter::ErrorReporter::report(e);
+                    })
+                }
+            }
+        )*
+    };
 }

--- a/riven/src/consts/mod.rs
+++ b/riven/src/consts/mod.rs
@@ -8,6 +8,11 @@
 
 mod macros;
 
+#[cfg(feature = "eserde")]
+pub use eserde::{EDeserialize as Deserialize, ESerialize as Serialize};
+#[cfg(not(feature = "eserde"))]
+pub use serde::{Deserialize, Serialize};
+
 #[rustfmt::skip]
 mod champion;
 pub use champion::*;

--- a/riven/src/consts/mod.rs
+++ b/riven/src/consts/mod.rs
@@ -8,11 +8,6 @@
 
 mod macros;
 
-#[cfg(feature = "eserde")]
-pub use eserde::{EDeserialize as Deserialize, ESerialize as Serialize};
-#[cfg(not(feature = "eserde"))]
-pub use serde::{Deserialize, Serialize};
-
 #[rustfmt::skip]
 mod champion;
 pub use champion::*;

--- a/riven/src/consts/route.rs
+++ b/riven/src/consts/route.rs
@@ -332,7 +332,7 @@ pub enum ValPlatformRoute {
 #[derive(PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[derive(IntoPrimitive, TryFromPrimitive)]
 #[derive(EnumString, EnumIter, Display, IntoStaticStr)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(crate::Serialize, crate::Deserialize)]
 #[derive(Clone, Copy)]
 #[repr(u8)]
 #[non_exhaustive]

--- a/riven/src/consts/route.rs
+++ b/riven/src/consts/route.rs
@@ -332,7 +332,7 @@ pub enum ValPlatformRoute {
 #[derive(PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[derive(IntoPrimitive, TryFromPrimitive)]
 #[derive(EnumString, EnumIter, Display, IntoStaticStr)]
-#[derive(crate::Serialize, crate::Deserialize)]
+#[derive(serde::Serialize, crate::de::Deserialize)]
 #[derive(Clone, Copy)]
 #[repr(u8)]
 #[non_exhaustive]

--- a/riven/src/consts/route.rs
+++ b/riven/src/consts/route.rs
@@ -6,6 +6,7 @@
 //           Do not directly edit!           //
 //                                           //
 ///////////////////////////////////////////////
+#![allow(clippy::upper_case_acronyms)]
 
 use num_enum::{ IntoPrimitive, TryFromPrimitive };
 use strum_macros::{ EnumString, EnumIter, Display, IntoStaticStr };

--- a/riven/src/consts/team.rs
+++ b/riven/src/consts/team.rs
@@ -29,3 +29,5 @@ pub enum Team {
     /// "killerTeamId" when Baron Nashor spawns and kills Rift Herald.
     OTHER = 300,
 }
+
+impl_edeserialize!(Team);

--- a/riven/src/consts/tier.rs
+++ b/riven/src/consts/tier.rs
@@ -2,8 +2,6 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 use strum::IntoEnumIterator;
 use strum_macros::{AsRefStr, Display, EnumString, IntoStaticStr};
 
-use crate::{Deserialize, Serialize};
-
 /// LoL and TFT ranked tiers, such as gold, diamond, challenger, etc.
 ///
 /// Sorts from lowest rank to highest rank.
@@ -26,8 +24,8 @@ use crate::{Deserialize, Serialize};
     Display,
     AsRefStr,
     IntoStaticStr,
-    Serialize,
-    Deserialize,
+    serde::Serialize,
+    crate::de::Deserialize,
 )]
 #[repr(u8)]
 pub enum Tier {

--- a/riven/src/consts/tier.rs
+++ b/riven/src/consts/tier.rs
@@ -1,7 +1,8 @@
 use num_enum::{IntoPrimitive, TryFromPrimitive};
-use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use strum_macros::{AsRefStr, Display, EnumString, IntoStaticStr};
+
+use crate::{Deserialize, Serialize};
 
 /// LoL and TFT ranked tiers, such as gold, diamond, challenger, etc.
 ///

--- a/riven/src/consts/tier.rs
+++ b/riven/src/consts/tier.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::upper_case_acronyms)]
+
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use strum::IntoEnumIterator;
 use strum_macros::{AsRefStr, Display, EnumString, IntoStaticStr};

--- a/riven/src/endpoints.rs
+++ b/riven/src/endpoints.rs
@@ -1184,6 +1184,7 @@ impl<'a> LorDeckV1<'a> {
         let mut request = request.bearer_auth(access_token);
         if let Some(clear) = self.base.get_rso_clear_header() { request = request.header(clear, "") }
         let request = request.body(serde_json::ser::to_vec(body).unwrap());
+        req.headers_mut().insert(reqwest::header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
         let future = self.base.execute_val::<String>("lor-deck-v1.createDeck", route_str, request);
         #[cfg(feature = "tracing")]
         let future = future.instrument(tracing::info_span!("lor-deck-v1.createDeck", route = route_str));
@@ -2054,6 +2055,7 @@ impl<'a> TournamentStubV5<'a> {
         let request = request.query(&[ ("tournamentId", tournament_id) ]);
         let request = if let Some(count) = count { request.query(&[ ("count", count) ]) } else { request };
         let request = request.body(serde_json::ser::to_vec(body).unwrap());
+        req.headers_mut().insert(reqwest::header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
         let future = self.base.execute_val::<Vec<String>>("tournament-stub-v5.createTournamentCode", route_str, request);
         #[cfg(feature = "tracing")]
         let future = future.instrument(tracing::info_span!("tournament-stub-v5.createTournamentCode", route = route_str));
@@ -2119,6 +2121,7 @@ impl<'a> TournamentStubV5<'a> {
         let route_str = route.into();
         let request = self.base.request(Method::POST, route_str, "/lol/tournament-stub/v5/providers");
         let request = request.body(serde_json::ser::to_vec(body).unwrap());
+        req.headers_mut().insert(reqwest::header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
         let future = self.base.execute_val::<i32>("tournament-stub-v5.registerProviderData", route_str, request);
         #[cfg(feature = "tracing")]
         let future = future.instrument(tracing::info_span!("tournament-stub-v5.registerProviderData", route = route_str));
@@ -2140,6 +2143,7 @@ impl<'a> TournamentStubV5<'a> {
         let route_str = route.into();
         let request = self.base.request(Method::POST, route_str, "/lol/tournament-stub/v5/tournaments");
         let request = request.body(serde_json::ser::to_vec(body).unwrap());
+        req.headers_mut().insert(reqwest::header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
         let future = self.base.execute_val::<i32>("tournament-stub-v5.registerTournament", route_str, request);
         #[cfg(feature = "tracing")]
         let future = future.instrument(tracing::info_span!("tournament-stub-v5.registerTournament", route = route_str));
@@ -2177,6 +2181,7 @@ impl<'a> TournamentV5<'a> {
         let request = request.query(&[ ("tournamentId", tournament_id) ]);
         let request = if let Some(count) = count { request.query(&[ ("count", count) ]) } else { request };
         let request = request.body(serde_json::ser::to_vec(body).unwrap());
+        req.headers_mut().insert(reqwest::header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
         let future = self.base.execute_val::<Vec<String>>("tournament-v5.createTournamentCode", route_str, request);
         #[cfg(feature = "tracing")]
         let future = future.instrument(tracing::info_span!("tournament-v5.createTournamentCode", route = route_str));
@@ -2220,6 +2225,7 @@ impl<'a> TournamentV5<'a> {
         let route_str = route.into();
         let request = self.base.request(Method::PUT, route_str, &format!("/lol/tournament/v5/codes/{}", tournament_code));
         let request = request.body(serde_json::ser::to_vec(body).unwrap());
+        req.headers_mut().insert(reqwest::header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
         let future = self.base.execute("tournament-v5.updateCode", route_str, request);
         #[cfg(feature = "tracing")]
         let future = future.instrument(tracing::info_span!("tournament-v5.updateCode", route = route_str));
@@ -2291,6 +2297,7 @@ impl<'a> TournamentV5<'a> {
         let route_str = route.into();
         let request = self.base.request(Method::POST, route_str, "/lol/tournament/v5/providers");
         let request = request.body(serde_json::ser::to_vec(body).unwrap());
+        req.headers_mut().insert(reqwest::header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
         let future = self.base.execute_val::<i32>("tournament-v5.registerProviderData", route_str, request);
         #[cfg(feature = "tracing")]
         let future = future.instrument(tracing::info_span!("tournament-v5.registerProviderData", route = route_str));
@@ -2312,6 +2319,7 @@ impl<'a> TournamentV5<'a> {
         let route_str = route.into();
         let request = self.base.request(Method::POST, route_str, "/lol/tournament/v5/tournaments");
         let request = request.body(serde_json::ser::to_vec(body).unwrap());
+        req.headers_mut().insert(reqwest::header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
         let future = self.base.execute_val::<i32>("tournament-v5.registerTournament", route_str, request);
         #[cfg(feature = "tracing")]
         let future = future.instrument(tracing::info_span!("tournament-v5.registerTournament", route = route_str));

--- a/riven/src/endpoints.rs
+++ b/riven/src/endpoints.rs
@@ -8,7 +8,7 @@
 ///////////////////////////////////////////////
 
 // http://www.mingweisamuel.com/riotapi-schema/tool/
-// Version 1b37b11075bdad584e6a46a1bdeffa7ad35c4303
+// Version 0ec1ee73a0d4f3138f9cbbe51b2787d41c3d8892
 
 //! Automatically generated endpoint handles.
 #![allow(clippy::let_and_return, clippy::too_many_arguments)]

--- a/riven/src/endpoints.rs
+++ b/riven/src/endpoints.rs
@@ -1183,8 +1183,9 @@ impl<'a> LorDeckV1<'a> {
         let request = self.base.request(Method::POST, route_str, "/lor/deck/v1/decks/me");
         let mut request = request.bearer_auth(access_token);
         if let Some(clear) = self.base.get_rso_clear_header() { request = request.header(clear, "") }
-        let request = request.body(serde_json::ser::to_vec(body).unwrap());
-        req.headers_mut().insert(reqwest::header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        let request = request
+            .body(serde_json::ser::to_vec(body).unwrap())
+            .header(reqwest::header::CONTENT_TYPE, "application/json");
         let future = self.base.execute_val::<String>("lor-deck-v1.createDeck", route_str, request);
         #[cfg(feature = "tracing")]
         let future = future.instrument(tracing::info_span!("lor-deck-v1.createDeck", route = route_str));
@@ -2054,8 +2055,9 @@ impl<'a> TournamentStubV5<'a> {
         let request = self.base.request(Method::POST, route_str, "/lol/tournament-stub/v5/codes");
         let request = request.query(&[ ("tournamentId", tournament_id) ]);
         let request = if let Some(count) = count { request.query(&[ ("count", count) ]) } else { request };
-        let request = request.body(serde_json::ser::to_vec(body).unwrap());
-        req.headers_mut().insert(reqwest::header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        let request = request
+            .body(serde_json::ser::to_vec(body).unwrap())
+            .header(reqwest::header::CONTENT_TYPE, "application/json");
         let future = self.base.execute_val::<Vec<String>>("tournament-stub-v5.createTournamentCode", route_str, request);
         #[cfg(feature = "tracing")]
         let future = future.instrument(tracing::info_span!("tournament-stub-v5.createTournamentCode", route = route_str));
@@ -2120,8 +2122,9 @@ impl<'a> TournamentStubV5<'a> {
     {
         let route_str = route.into();
         let request = self.base.request(Method::POST, route_str, "/lol/tournament-stub/v5/providers");
-        let request = request.body(serde_json::ser::to_vec(body).unwrap());
-        req.headers_mut().insert(reqwest::header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        let request = request
+            .body(serde_json::ser::to_vec(body).unwrap())
+            .header(reqwest::header::CONTENT_TYPE, "application/json");
         let future = self.base.execute_val::<i32>("tournament-stub-v5.registerProviderData", route_str, request);
         #[cfg(feature = "tracing")]
         let future = future.instrument(tracing::info_span!("tournament-stub-v5.registerProviderData", route = route_str));
@@ -2142,8 +2145,9 @@ impl<'a> TournamentStubV5<'a> {
     {
         let route_str = route.into();
         let request = self.base.request(Method::POST, route_str, "/lol/tournament-stub/v5/tournaments");
-        let request = request.body(serde_json::ser::to_vec(body).unwrap());
-        req.headers_mut().insert(reqwest::header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        let request = request
+            .body(serde_json::ser::to_vec(body).unwrap())
+            .header(reqwest::header::CONTENT_TYPE, "application/json");
         let future = self.base.execute_val::<i32>("tournament-stub-v5.registerTournament", route_str, request);
         #[cfg(feature = "tracing")]
         let future = future.instrument(tracing::info_span!("tournament-stub-v5.registerTournament", route = route_str));
@@ -2180,8 +2184,9 @@ impl<'a> TournamentV5<'a> {
         let request = self.base.request(Method::POST, route_str, "/lol/tournament/v5/codes");
         let request = request.query(&[ ("tournamentId", tournament_id) ]);
         let request = if let Some(count) = count { request.query(&[ ("count", count) ]) } else { request };
-        let request = request.body(serde_json::ser::to_vec(body).unwrap());
-        req.headers_mut().insert(reqwest::header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        let request = request
+            .body(serde_json::ser::to_vec(body).unwrap())
+            .header(reqwest::header::CONTENT_TYPE, "application/json");
         let future = self.base.execute_val::<Vec<String>>("tournament-v5.createTournamentCode", route_str, request);
         #[cfg(feature = "tracing")]
         let future = future.instrument(tracing::info_span!("tournament-v5.createTournamentCode", route = route_str));
@@ -2224,8 +2229,9 @@ impl<'a> TournamentV5<'a> {
     {
         let route_str = route.into();
         let request = self.base.request(Method::PUT, route_str, &format!("/lol/tournament/v5/codes/{}", tournament_code));
-        let request = request.body(serde_json::ser::to_vec(body).unwrap());
-        req.headers_mut().insert(reqwest::header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        let request = request
+            .body(serde_json::ser::to_vec(body).unwrap())
+            .header(reqwest::header::CONTENT_TYPE, "application/json");
         let future = self.base.execute("tournament-v5.updateCode", route_str, request);
         #[cfg(feature = "tracing")]
         let future = future.instrument(tracing::info_span!("tournament-v5.updateCode", route = route_str));
@@ -2296,8 +2302,9 @@ impl<'a> TournamentV5<'a> {
     {
         let route_str = route.into();
         let request = self.base.request(Method::POST, route_str, "/lol/tournament/v5/providers");
-        let request = request.body(serde_json::ser::to_vec(body).unwrap());
-        req.headers_mut().insert(reqwest::header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        let request = request
+            .body(serde_json::ser::to_vec(body).unwrap())
+            .header(reqwest::header::CONTENT_TYPE, "application/json");
         let future = self.base.execute_val::<i32>("tournament-v5.registerProviderData", route_str, request);
         #[cfg(feature = "tracing")]
         let future = future.instrument(tracing::info_span!("tournament-v5.registerProviderData", route = route_str));
@@ -2318,8 +2325,9 @@ impl<'a> TournamentV5<'a> {
     {
         let route_str = route.into();
         let request = self.base.request(Method::POST, route_str, "/lol/tournament/v5/tournaments");
-        let request = request.body(serde_json::ser::to_vec(body).unwrap());
-        req.headers_mut().insert(reqwest::header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        let request = request
+            .body(serde_json::ser::to_vec(body).unwrap())
+            .header(reqwest::header::CONTENT_TYPE, "application/json");
         let future = self.base.execute_val::<i32>("tournament-v5.registerTournament", route_str, request);
         #[cfg(feature = "tracing")]
         let future = future.instrument(tracing::info_span!("tournament-v5.registerTournament", route = route_str));

--- a/riven/src/error.rs
+++ b/riven/src/error.rs
@@ -2,6 +2,11 @@ use std::fmt;
 
 use reqwest::{Response, StatusCode};
 
+#[cfg(not(feature = "eserde"))]
+use serde_json::Error as SerdeError;
+#[cfg(feature = "eserde")]
+use eserde::DeserializationErrors as SerdeError;
+
 /// Result containing RiotApiError on failure.
 pub type Result<T> = std::result::Result<T, RiotApiError>;
 
@@ -9,7 +14,7 @@ pub type Result<T> = std::result::Result<T, RiotApiError>;
 #[derive(Debug)]
 pub struct RiotApiError {
     reqwest_errors: Vec<reqwest::Error>,
-    serde_error: Option<serde_json::Error>,
+    serde_error: Option<SerdeError>,
     retries: u8,
     response: Option<Response>,
     status_code: Option<StatusCode>,
@@ -17,7 +22,7 @@ pub struct RiotApiError {
 impl RiotApiError {
     pub(crate) fn new(
         reqwest_errors: Vec<reqwest::Error>,
-        serde_error: Option<serde_json::Error>,
+        serde_error: Option<SerdeError>,
         retries: u8,
         response: Option<Response>,
         status_code: Option<StatusCode>,
@@ -45,7 +50,7 @@ impl RiotApiError {
     }
 
     /// Returns the final deserialization error if any occured.
-    pub fn serde_error(&self) -> Option<&serde_json::Error> {
+    pub fn serde_error(&self) -> Option<&SerdeError> {
         self.serde_error.as_ref()
     }
 

--- a/riven/src/error.rs
+++ b/riven/src/error.rs
@@ -9,7 +9,7 @@ pub type Result<T> = std::result::Result<T, RiotApiError>;
 #[derive(Debug)]
 pub struct RiotApiError {
     reqwest_errors: Vec<reqwest::Error>,
-    serde_error: Option<crate::de::Error>,
+    de_error: Option<crate::de::Error>,
     retries: u8,
     response: Option<Response>,
     status_code: Option<StatusCode>,
@@ -24,7 +24,7 @@ impl RiotApiError {
     ) -> Self {
         Self {
             reqwest_errors,
-            serde_error,
+            de_error: serde_error,
             retries,
             response,
             status_code,
@@ -32,9 +32,9 @@ impl RiotApiError {
     }
 
     /// Returns the final `reqwest::Error`, for the final failed request, or panics if this was a deserialization error.
-    #[deprecated = "Use `reqwest_errors()` instead."]
+    #[deprecated = "Use `reqwest_errors()` or `de_error()` instead."]
     pub fn source_reqwest_error(&self) -> &reqwest::Error {
-        &self.reqwest_errors.last().unwrap()
+        self.reqwest_errors.last().unwrap()
     }
 
     /// Returns all `reqwest::Error`s across all retries, in the chronological order they occurred.
@@ -45,8 +45,8 @@ impl RiotApiError {
     }
 
     /// Returns the final deserialization error if any occured.
-    pub fn serde_error(&self) -> Option<&crate::de::Error> {
-        self.serde_error.as_ref()
+    pub fn de_error(&self) -> Option<&crate::de::Error> {
+        self.de_error.as_ref()
     }
 
     /// The number of retires attempted. Zero means exactly one request, zero retries.
@@ -54,7 +54,7 @@ impl RiotApiError {
         self.retries
     }
 
-    /// The failed response.
+    /// The failed, unparsed response.
     /// `Some(&reqwest::Response)` if the request was sent and failed.
     /// `None` if the request was not sent, OR if parsing the response JSON failed.
     pub fn response(&self) -> Option<&Response> {
@@ -79,23 +79,29 @@ impl fmt::Display for RiotApiError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
             f,
-            "Riot API request failed after {} retries with status code {:?}.",
-            self.retries, self.status_code
+            "Riot API request failed after {} retries with status code {:?}{}:",
+            self.retries(),
+            self.status_code(),
+            if self.response().is_some() {
+                " (response not parsed)"
+            } else {
+                ""
+            },
         )?;
-        for (i, reqwest_error) in self.reqwest_errors.iter().enumerate() {
-            writeln!(f, "Reqwest error {}: {}", i + 1, reqwest_error)?;
+        for (i, reqwest_error) in self.reqwest_errors().iter().enumerate() {
+            writeln!(f, "- Reqwest error {}: {}", i + 1, reqwest_error)?;
         }
-        if let Some(response) = &self.response {
-            writeln!(f, "Response: {:?}", response)?;
-        }
-        if let Some(serde_error) = &self.serde_error {
-            writeln!(f, "Deserialization error: {}", serde_error)?;
+        if let Some(serde_error) = self.de_error() {
+            writeln!(f, "- Deserialization error: {}", serde_error)?;
         }
         Ok(())
     }
 }
 impl std::error::Error for RiotApiError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.reqwest_errors().last().map(|e| e as _)
+        self.reqwest_errors()
+            .last()
+            .map(|e| e as _)
+            .or_else(|| self.de_error().map(|e| e as _))
     }
 }

--- a/riven/src/error.rs
+++ b/riven/src/error.rs
@@ -1,55 +1,73 @@
 use std::fmt;
 
-use reqwest::{Error, Response, StatusCode};
+use reqwest::{Response, StatusCode};
 
 /// Result containing RiotApiError on failure.
 pub type Result<T> = std::result::Result<T, RiotApiError>;
 
 /// An error that occurred while processing a Riot API request.
-///
-/// Although Riven may make multiple requests due to retries, this will always
-/// contain exactly one reqwest::Error for the final request which failed.
 #[derive(Debug)]
 pub struct RiotApiError {
-    reqwest_error: Error,
+    reqwest_errors: Vec<reqwest::Error>,
+    serde_error: Option<serde_json::Error>,
     retries: u8,
     response: Option<Response>,
     status_code: Option<StatusCode>,
 }
 impl RiotApiError {
     pub(crate) fn new(
-        reqwest_error: Error,
+        reqwest_errors: Vec<reqwest::Error>,
+        serde_error: Option<serde_json::Error>,
         retries: u8,
         response: Option<Response>,
         status_code: Option<StatusCode>,
     ) -> Self {
         Self {
-            reqwest_error,
+            reqwest_errors,
+            serde_error,
             retries,
             response,
             status_code,
         }
     }
-    /// The reqwest::Error for the final failed request.
-    pub fn source_reqwest_error(&self) -> &Error {
-        &self.reqwest_error
+
+    /// Returns the final `reqwest::Error`, for the final failed request, or panics if this was a deserialization error.
+    #[deprecated = "Use `reqwest_errors()` instead."]
+    pub fn source_reqwest_error(&self) -> &reqwest::Error {
+        &self.reqwest_errors.last().unwrap()
     }
+
+    /// Returns all `reqwest::Error`s across all retries, in the chronological order they occurred.
+    ///
+    /// May be empty if there was a deserialization error.
+    pub fn reqwest_errors(&self) -> &[reqwest::Error] {
+        &self.reqwest_errors
+    }
+
+    /// Returns the final deserialization error if any occured.
+    pub fn serde_error(&self) -> Option<&serde_json::Error> {
+        self.serde_error.as_ref()
+    }
+
     /// The number of retires attempted. Zero means exactly one request, zero retries.
     pub fn retries(&self) -> u8 {
         self.retries
     }
+
     /// The failed response.
     /// `Some(&reqwest::Response)` if the request was sent and failed.
     /// `None` if the request was not sent, OR if parsing the response JSON failed.
     pub fn response(&self) -> Option<&Response> {
         self.response.as_ref()
     }
+
     /// The failed response.
     /// `Some(reqwest::Response)` if the request was sent and failed.
     /// `None` if the request was not sent, OR if parsing the response JSON failed.
     pub fn take_response(&mut self) -> Option<Response> {
         self.response.take()
     }
+
     /// The failed response's HTTP status code.
     /// `Some(reqwest::StatusCode)` if the request was sent and failed, OR if parsing the response JSON failed.
     /// `None` if the request was not sent.
@@ -64,6 +82,6 @@ impl fmt::Display for RiotApiError {
 }
 impl std::error::Error for RiotApiError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(&self.reqwest_error)
+        self.reqwest_errors().last().map(|e| e as _)
     }
 }

--- a/riven/src/error.rs
+++ b/riven/src/error.rs
@@ -2,11 +2,6 @@ use std::fmt;
 
 use reqwest::{Response, StatusCode};
 
-#[cfg(not(feature = "eserde"))]
-use serde_json::Error as SerdeError;
-#[cfg(feature = "eserde")]
-use eserde::DeserializationErrors as SerdeError;
-
 /// Result containing RiotApiError on failure.
 pub type Result<T> = std::result::Result<T, RiotApiError>;
 
@@ -14,7 +9,7 @@ pub type Result<T> = std::result::Result<T, RiotApiError>;
 #[derive(Debug)]
 pub struct RiotApiError {
     reqwest_errors: Vec<reqwest::Error>,
-    serde_error: Option<SerdeError>,
+    serde_error: Option<crate::de::Error>,
     retries: u8,
     response: Option<Response>,
     status_code: Option<StatusCode>,
@@ -22,7 +17,7 @@ pub struct RiotApiError {
 impl RiotApiError {
     pub(crate) fn new(
         reqwest_errors: Vec<reqwest::Error>,
-        serde_error: Option<SerdeError>,
+        serde_error: Option<crate::de::Error>,
         retries: u8,
         response: Option<Response>,
         status_code: Option<StatusCode>,
@@ -50,7 +45,7 @@ impl RiotApiError {
     }
 
     /// Returns the final deserialization error if any occured.
-    pub fn serde_error(&self) -> Option<&SerdeError> {
+    pub fn serde_error(&self) -> Option<&crate::de::Error> {
         self.serde_error.as_ref()
     }
 
@@ -82,7 +77,21 @@ impl RiotApiError {
 }
 impl fmt::Display for RiotApiError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:#?}", self)
+        writeln!(
+            f,
+            "Riot API request failed after {} retries with status code {:?}.",
+            self.retries, self.status_code
+        )?;
+        for (i, reqwest_error) in self.reqwest_errors.iter().enumerate() {
+            writeln!(f, "Reqwest error {}: {}", i + 1, reqwest_error)?;
+        }
+        if let Some(response) = &self.response {
+            writeln!(f, "Response: {:?}", response)?;
+        }
+        if let Some(serde_error) = &self.serde_error {
+            writeln!(f, "Deserialization error: {}", serde_error)?;
+        }
+        Ok(())
     }
 }
 impl std::error::Error for RiotApiError {

--- a/riven/src/lib.rs
+++ b/riven/src/lib.rs
@@ -191,10 +191,10 @@
 //!
 
 pub use serde::Serialize;
-#[cfg(feature = "eserde")]
-pub use eserde::Deserialize;
 #[cfg(not(feature = "eserde"))]
-pub use serde::de::Deserialize;
+pub use serde::{Deserialize, de::Deserialize};
+#[cfg(feature = "eserde")]
+pub use eserde::{Deserialize, EDeserialize as Deserialize};
 
 // Re-exported reqwest types.
 pub use reqwest;

--- a/riven/src/lib.rs
+++ b/riven/src/lib.rs
@@ -190,14 +190,12 @@
 //! To run the srcgen use `node riven/srcgen` from the repository root.
 //!
 
-pub use serde::Serialize;
-#[cfg(not(feature = "eserde"))]
-pub use serde::{Deserialize, de::Deserialize};
-#[cfg(feature = "eserde")]
-pub use eserde::{Deserialize, EDeserialize as Deserialize};
-
-// Re-exported reqwest types.
+// Re-exported crates.
 pub use reqwest;
+pub use serde;
+#[cfg(feature = "eserde")]
+pub use eserde;
+
 
 mod config;
 pub use config::RiotApiConfig;
@@ -241,4 +239,18 @@ pub mod time {
     pub use tokio::time::sleep;
     #[cfg(target_family = "wasm")]
     pub use gloo_timers::future::sleep;
+}
+
+/// Deserialization utilities from either `serde_json` or `eserde`.
+#[rustfmt::skip]
+pub mod de {
+    #[cfg(not(feature = "eserde"))]
+    pub use serde::Deserialize;
+    #[cfg(not(feature = "eserde"))]
+    pub use serde_json::{Error, from_str, from_slice};
+
+    #[cfg(feature = "eserde")]
+    pub use eserde::{Deserialize, EDeserialize as Deserialize, DeserializationErrors as Error};
+    #[cfg(feature = "eserde")]
+    pub use eserde::json::{from_str, from_slice};
 }

--- a/riven/src/lib.rs
+++ b/riven/src/lib.rs
@@ -190,6 +190,12 @@
 //! To run the srcgen use `node riven/srcgen` from the repository root.
 //!
 
+pub use serde::Serialize;
+#[cfg(feature = "eserde")]
+pub use eserde::Deserialize;
+#[cfg(not(feature = "eserde"))]
+pub use serde::de::Deserialize;
+
 // Re-exported reqwest types.
 pub use reqwest;
 

--- a/riven/src/meta.rs
+++ b/riven/src/meta.rs
@@ -8,7 +8,7 @@
 ///////////////////////////////////////////////
 
 // http://www.mingweisamuel.com/riotapi-schema/tool/
-// Version 1b37b11075bdad584e6a46a1bdeffa7ad35c4303
+// Version 0ec1ee73a0d4f3138f9cbbe51b2787d41c3d8892
 
 //! Metadata about the Riot API and Riven.
 //!

--- a/riven/src/models.rs
+++ b/riven/src/models.rs
@@ -26,7 +26,7 @@
 pub mod account_v1 {
     /// Account data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Account {
         #[serde(rename = "puuid")]
@@ -42,7 +42,7 @@ pub mod account_v1 {
     }
     /// ActiveShard data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ActiveShard {
         #[serde(rename = "puuid")]
@@ -65,7 +65,7 @@ pub mod champion_mastery_v4 {
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ChampionMastery {
         /// Player Universal Unique Identifier. Exact length of 78 characters. (Encrypted)
@@ -112,7 +112,7 @@ pub mod champion_mastery_v4 {
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct NextSeasonMilestones {
         #[serde(rename = "requireGradeCounts")]
@@ -136,7 +136,7 @@ pub mod champion_mastery_v4 {
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct RewardConfig {
         /// Reward value
@@ -158,7 +158,7 @@ pub mod champion_mastery_v4 {
 pub mod champion_v3 {
     /// ChampionInfo data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ChampionInfo {
         #[serde(rename = "maxNewPlayerLevel")]
@@ -177,7 +177,7 @@ pub mod champion_v3 {
 pub mod clash_v1 {
     /// Player data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Player {
         #[serde(rename = "summonerId")]
@@ -196,7 +196,7 @@ pub mod clash_v1 {
     }
     /// Team data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Team {
         #[serde(rename = "id")]
@@ -220,7 +220,7 @@ pub mod clash_v1 {
     }
     /// Tournament data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Tournament {
         #[serde(rename = "id")]
@@ -237,7 +237,7 @@ pub mod clash_v1 {
     }
     /// TournamentPhase data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TournamentPhase {
         #[serde(rename = "id")]
@@ -258,7 +258,7 @@ pub mod clash_v1 {
 pub mod league_exp_v4 {
     /// LeagueEntry data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LeagueEntry {
         #[serde(rename = "leagueId")]
@@ -298,7 +298,7 @@ pub mod league_exp_v4 {
     }
     /// MiniSeries data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct MiniSeries {
         #[serde(rename = "losses")]
@@ -319,7 +319,7 @@ pub mod league_exp_v4 {
 pub mod league_v4 {
     /// LeagueList data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LeagueList {
         #[serde(rename = "leagueId")]
@@ -338,7 +338,7 @@ pub mod league_v4 {
     }
     /// LeagueItem data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LeagueItem {
         #[serde(rename = "freshBlood")]
@@ -371,7 +371,7 @@ pub mod league_v4 {
     }
     /// MiniSeries data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct MiniSeries {
         #[serde(rename = "losses")]
@@ -385,7 +385,7 @@ pub mod league_v4 {
     }
     /// LeagueEntry data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LeagueEntry {
         #[serde(rename = "leagueId")]
@@ -435,7 +435,7 @@ pub mod league_v4 {
 pub mod lol_challenges_v1 {
     /// ChallengeConfigInfo data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ChallengeConfigInfo {
         #[serde(rename = "id")]
@@ -469,7 +469,7 @@ pub mod lol_challenges_v1 {
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct State {
     }
@@ -480,13 +480,13 @@ pub mod lol_challenges_v1 {
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Tracking {
     }
     /// ApexPlayerInfo data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ApexPlayerInfo {
         #[serde(rename = "puuid")]
@@ -511,13 +511,13 @@ pub mod lol_challenges_v1 {
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Level {
     }
     /// PlayerInfo data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlayerInfo {
         #[serde(rename = "challenges")]
@@ -531,7 +531,7 @@ pub mod lol_challenges_v1 {
     }
     /// ChallengeInfo data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ChallengeInfo {
         #[serde(rename = "challengeId")]
@@ -554,7 +554,7 @@ pub mod lol_challenges_v1 {
     }
     /// PlayerClientPreferences data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlayerClientPreferences {
         #[serde(rename = "bannerAccent")]
@@ -575,7 +575,7 @@ pub mod lol_challenges_v1 {
     }
     /// ChallengePoints data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ChallengePoints {
         #[serde(rename = "level")]
@@ -601,7 +601,7 @@ pub mod lol_rso_match_v1 {
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Match {
     }
@@ -611,7 +611,7 @@ pub mod lol_rso_match_v1 {
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Timeline {
     }
@@ -624,7 +624,7 @@ pub mod lol_rso_match_v1 {
 pub mod lol_status_v4 {
     /// PlatformData data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlatformData {
         #[serde(rename = "id")]
@@ -640,7 +640,7 @@ pub mod lol_status_v4 {
     }
     /// Status data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Status {
         #[serde(rename = "id")]
@@ -671,7 +671,7 @@ pub mod lol_status_v4 {
     }
     /// Content data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Content {
         #[serde(rename = "locale")]
@@ -681,7 +681,7 @@ pub mod lol_status_v4 {
     }
     /// Update data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Update {
         #[serde(rename = "id")]
@@ -709,7 +709,7 @@ pub mod lol_status_v4 {
 pub mod lor_deck_v1 {
     /// Deck data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Deck {
         #[serde(rename = "id")]
@@ -721,7 +721,7 @@ pub mod lor_deck_v1 {
     }
     /// NewDeck data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct NewDeck {
         #[serde(rename = "name")]
@@ -738,7 +738,7 @@ pub mod lor_deck_v1 {
 pub mod lor_inventory_v1 {
     /// Card data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Card {
         #[serde(rename = "code")]
@@ -755,7 +755,7 @@ pub mod lor_inventory_v1 {
 pub mod lor_match_v1 {
     /// Match data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Match {
         /// Match metadata.
@@ -767,7 +767,7 @@ pub mod lor_match_v1 {
     }
     /// Metadata data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Metadata {
         /// Match data version.
@@ -782,7 +782,7 @@ pub mod lor_match_v1 {
     }
     /// Info data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Info {
         /// (Legal values:  Constructed,  Expeditions,  Tutorial)
@@ -806,7 +806,7 @@ pub mod lor_match_v1 {
     }
     /// Player data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Player {
         #[serde(rename = "puuid")]
@@ -833,7 +833,7 @@ pub mod lor_match_v1 {
 pub mod lor_ranked_v1 {
     /// Leaderboard data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Leaderboard {
         /// A list of players in Master tier.
@@ -842,7 +842,7 @@ pub mod lor_ranked_v1 {
     }
     /// Player data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Player {
         #[serde(rename = "name")]
@@ -862,7 +862,7 @@ pub mod lor_ranked_v1 {
 pub mod lor_status_v1 {
     /// PlatformData data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlatformData {
         #[serde(rename = "id")]
@@ -878,7 +878,7 @@ pub mod lor_status_v1 {
     }
     /// Status data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Status {
         #[serde(rename = "id")]
@@ -905,7 +905,7 @@ pub mod lor_status_v1 {
     }
     /// Content data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Content {
         #[serde(rename = "locale")]
@@ -915,7 +915,7 @@ pub mod lor_status_v1 {
     }
     /// Update data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Update {
         #[serde(rename = "id")]
@@ -943,7 +943,7 @@ pub mod lor_status_v1 {
 pub mod match_v5 {
     /// Match data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Match {
         /// Match metadata.
@@ -955,7 +955,7 @@ pub mod match_v5 {
     }
     /// Metadata data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Metadata {
         /// Match data version.
@@ -970,7 +970,7 @@ pub mod match_v5 {
     }
     /// Info data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Info {
         /// Refer to indicate if the game ended in termination.
@@ -1026,7 +1026,7 @@ pub mod match_v5 {
     }
     /// Participant data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Participant {
         /// Yellow crossed swords
@@ -1408,7 +1408,7 @@ pub mod match_v5 {
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Challenges {
         #[serde(rename = "12AssistStreakCount")]
@@ -1861,7 +1861,7 @@ pub mod match_v5 {
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Missions {
         #[serde(rename = "playerScore0", alias = "PlayerScore0")]
@@ -1903,7 +1903,7 @@ pub mod match_v5 {
     }
     /// Perks data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Perks {
         #[serde(rename = "statPerks")]
@@ -1913,7 +1913,7 @@ pub mod match_v5 {
     }
     /// PerkStats data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PerkStats {
         #[serde(rename = "defense")]
@@ -1925,7 +1925,7 @@ pub mod match_v5 {
     }
     /// PerkStyle data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PerkStyle {
         #[serde(rename = "description")]
@@ -1937,7 +1937,7 @@ pub mod match_v5 {
     }
     /// PerkStyleSelection data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PerkStyleSelection {
         #[serde(rename = "perk")]
@@ -1951,7 +1951,7 @@ pub mod match_v5 {
     }
     /// Team data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Team {
         #[serde(rename = "bans")]
@@ -1968,7 +1968,7 @@ pub mod match_v5 {
     }
     /// Ban data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Ban {
         #[serde(rename = "championId")]
@@ -1978,7 +1978,7 @@ pub mod match_v5 {
     }
     /// Objectives data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Objectives {
         #[serde(rename = "baron")]
@@ -2002,7 +2002,7 @@ pub mod match_v5 {
     }
     /// Objective data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Objective {
         #[serde(rename = "first")]
@@ -2012,7 +2012,7 @@ pub mod match_v5 {
     }
     /// Timeline data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Timeline {
         /// Match metadata.
@@ -2024,7 +2024,7 @@ pub mod match_v5 {
     }
     /// MetadataTimeLine data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct MetadataTimeLine {
         /// Match data version.
@@ -2039,7 +2039,7 @@ pub mod match_v5 {
     }
     /// InfoTimeLine data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct InfoTimeLine {
         /// Refer to indicate if the game ended in termination.
@@ -2059,7 +2059,7 @@ pub mod match_v5 {
     }
     /// ParticipantTimeLine data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ParticipantTimeLine {
         #[serde(rename = "participantId")]
@@ -2069,7 +2069,7 @@ pub mod match_v5 {
     }
     /// FramesTimeLine data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct FramesTimeLine {
         #[serde(rename = "events")]
@@ -2082,7 +2082,7 @@ pub mod match_v5 {
     }
     /// EventsTimeLine data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct EventsTimeLine {
         #[serde(rename = "timestamp")]
@@ -2200,7 +2200,7 @@ pub mod match_v5 {
     }
     /// ParticipantFrames data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ParticipantFrames {
         /// Key value mapping for each participant
@@ -2209,7 +2209,7 @@ pub mod match_v5 {
     }
     /// ParticipantFrame data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ParticipantFrame {
         #[serde(rename = "championStats")]
@@ -2239,7 +2239,7 @@ pub mod match_v5 {
     }
     /// ChampionStats data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ChampionStats {
         #[serde(rename = "abilityHaste")]
@@ -2298,7 +2298,7 @@ pub mod match_v5 {
     }
     /// DamageStats data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct DamageStats {
         #[serde(rename = "magicDamageDone")]
@@ -2328,7 +2328,7 @@ pub mod match_v5 {
     }
     /// Position data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Position {
         #[serde(rename = "x")]
@@ -2338,7 +2338,7 @@ pub mod match_v5 {
     }
     /// Feats data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Feats {
         #[serde(rename = "EPIC_MONSTER_KILL")]
@@ -2353,7 +2353,7 @@ pub mod match_v5 {
     }
     /// MatchTimelineVictimDamage data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct MatchTimelineVictimDamage {
         #[serde(rename = "basic")]
@@ -2377,7 +2377,7 @@ pub mod match_v5 {
     }
     /// Feat data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Feat {
         #[serde(rename = "featState")]
@@ -2393,7 +2393,7 @@ pub mod match_v5 {
 pub mod spectator_tft_v5 {
     /// CurrentGameInfo data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct CurrentGameInfo {
         /// The ID of the game
@@ -2433,7 +2433,7 @@ pub mod spectator_tft_v5 {
     }
     /// BannedChampion data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct BannedChampion {
         /// The turn during which the champion was banned
@@ -2448,7 +2448,7 @@ pub mod spectator_tft_v5 {
     }
     /// Observer data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Observer {
         /// Key used to decrypt the spectator grid game data for playback
@@ -2457,7 +2457,7 @@ pub mod spectator_tft_v5 {
     }
     /// CurrentGameParticipant data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct CurrentGameParticipant {
         /// The ID of the champion played by this participant
@@ -2495,7 +2495,7 @@ pub mod spectator_tft_v5 {
     }
     /// Perks data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Perks {
         /// IDs of the perks/runes assigned.
@@ -2510,7 +2510,7 @@ pub mod spectator_tft_v5 {
     }
     /// GameCustomizationObject data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct GameCustomizationObject {
         /// Category identifier for Game Customization
@@ -2522,7 +2522,7 @@ pub mod spectator_tft_v5 {
     }
     /// FeaturedGames data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct FeaturedGames {
         /// The list of featured games
@@ -2535,7 +2535,7 @@ pub mod spectator_tft_v5 {
     }
     /// FeaturedGameInfo data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct FeaturedGameInfo {
         /// The game mode<br>
@@ -2573,7 +2573,7 @@ pub mod spectator_tft_v5 {
     }
     /// Participant data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Participant {
         /// The ID of the second summoner spell used by this participant
@@ -2612,7 +2612,7 @@ pub mod spectator_tft_v5 {
 pub mod spectator_v5 {
     /// CurrentGameInfo data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct CurrentGameInfo {
         /// The ID of the game
@@ -2652,7 +2652,7 @@ pub mod spectator_v5 {
     }
     /// BannedChampion data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct BannedChampion {
         /// The turn during which the champion was banned
@@ -2667,7 +2667,7 @@ pub mod spectator_v5 {
     }
     /// Observer data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Observer {
         /// Key used to decrypt the spectator grid game data for playback
@@ -2676,7 +2676,7 @@ pub mod spectator_v5 {
     }
     /// CurrentGameParticipant data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct CurrentGameParticipant {
         /// The ID of the champion played by this participant
@@ -2717,7 +2717,7 @@ pub mod spectator_v5 {
     }
     /// Perks data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Perks {
         /// IDs of the perks/runes assigned.
@@ -2732,7 +2732,7 @@ pub mod spectator_v5 {
     }
     /// GameCustomizationObject data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct GameCustomizationObject {
         /// Category identifier for Game Customization
@@ -2744,7 +2744,7 @@ pub mod spectator_v5 {
     }
     /// FeaturedGames data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct FeaturedGames {
         /// The list of featured games
@@ -2757,7 +2757,7 @@ pub mod spectator_v5 {
     }
     /// FeaturedGameInfo data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct FeaturedGameInfo {
         /// The game mode<br>
@@ -2795,7 +2795,7 @@ pub mod spectator_v5 {
     }
     /// Participant data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Participant {
         /// Flag indicating whether or not this participant is a bot
@@ -2841,7 +2841,7 @@ pub mod summoner_v4 {
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Summoner {
         /// Encrypted account ID. Max length 56 characters.
@@ -2872,7 +2872,7 @@ pub mod summoner_v4 {
 pub mod tft_league_v1 {
     /// LeagueList data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LeagueList {
         #[serde(rename = "leagueId")]
@@ -2891,7 +2891,7 @@ pub mod tft_league_v1 {
     }
     /// LeagueItem data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LeagueItem {
         #[serde(rename = "freshBlood")]
@@ -2924,7 +2924,7 @@ pub mod tft_league_v1 {
     }
     /// MiniSeries data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct MiniSeries {
         #[serde(rename = "losses")]
@@ -2938,7 +2938,7 @@ pub mod tft_league_v1 {
     }
     /// LeagueEntry data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LeagueEntry {
         /// Player Universal Unique Identifier. Exact length of 78 characters. (Encrypted)
@@ -3004,7 +3004,7 @@ pub mod tft_league_v1 {
     }
     /// TopRatedLadderEntry data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TopRatedLadderEntry {
         #[serde(rename = "summonerId")]
@@ -3029,7 +3029,7 @@ pub mod tft_league_v1 {
 pub mod tft_match_v1 {
     /// Match data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Match {
         /// Match metadata.
@@ -3041,7 +3041,7 @@ pub mod tft_match_v1 {
     }
     /// Metadata data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Metadata {
         /// Match data version.
@@ -3056,7 +3056,7 @@ pub mod tft_match_v1 {
     }
     /// Info data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Info {
         /// Unix timestamp.
@@ -3105,7 +3105,7 @@ pub mod tft_match_v1 {
     }
     /// Participant data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Participant {
         /// Participant's companion.
@@ -3164,7 +3164,7 @@ pub mod tft_match_v1 {
     }
     /// Trait data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Trait {
         /// Trait name.
@@ -3187,7 +3187,7 @@ pub mod tft_match_v1 {
     }
     /// Unit data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Unit {
         /// A list of the unit's items. Please refer to the Teamfight Tactics documentation for item ids.
@@ -3216,7 +3216,7 @@ pub mod tft_match_v1 {
     }
     /// Companion data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Companion {
         #[serde(rename = "item_ID")]
@@ -3231,7 +3231,7 @@ pub mod tft_match_v1 {
     }
     /// ParticipantMissions data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ParticipantMissions {
         #[serde(rename = "Assists")]
@@ -3388,7 +3388,7 @@ pub mod tft_match_v1 {
 pub mod tft_status_v1 {
     /// PlatformData data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlatformData {
         #[serde(rename = "id")]
@@ -3404,7 +3404,7 @@ pub mod tft_status_v1 {
     }
     /// Status data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Status {
         #[serde(rename = "id")]
@@ -3431,7 +3431,7 @@ pub mod tft_status_v1 {
     }
     /// Content data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Content {
         #[serde(rename = "locale")]
@@ -3441,7 +3441,7 @@ pub mod tft_status_v1 {
     }
     /// Update data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Update {
         #[serde(rename = "id")]
@@ -3473,7 +3473,7 @@ pub mod tft_summoner_v1 {
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Summoner {
         /// Encrypted account ID. Max length 56 characters.
@@ -3504,7 +3504,7 @@ pub mod tft_summoner_v1 {
 pub mod tournament_stub_v5 {
     /// TournamentCodeParametersV5 data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TournamentCodeParametersV5 {
         /// Optional list of encrypted puuids in order to validate the players eligible to join the lobby. NOTE: We currently do not enforce participants at the team level, but rather the aggregate of teamOne and teamTwo. We may add the ability to enforce at the team level in the future.
@@ -3536,7 +3536,7 @@ pub mod tournament_stub_v5 {
     }
     /// TournamentCodeV5 data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TournamentCodeV5 {
         /// The tournament code.
@@ -3582,7 +3582,7 @@ pub mod tournament_stub_v5 {
     }
     /// LobbyEventV5Wrapper data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LobbyEventV5Wrapper {
         #[serde(rename = "eventList")]
@@ -3590,7 +3590,7 @@ pub mod tournament_stub_v5 {
     }
     /// LobbyEventV5 data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LobbyEventV5 {
         /// Timestamp from the event
@@ -3605,7 +3605,7 @@ pub mod tournament_stub_v5 {
     }
     /// ProviderRegistrationParametersV5 data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ProviderRegistrationParametersV5 {
         /// The region in which the provider will be running tournaments.<br>
@@ -3618,7 +3618,7 @@ pub mod tournament_stub_v5 {
     }
     /// TournamentRegistrationParametersV5 data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TournamentRegistrationParametersV5 {
         /// The provider ID to specify the regional registered provider data to associate this tournament.
@@ -3638,7 +3638,7 @@ pub mod tournament_stub_v5 {
 pub mod tournament_v5 {
     /// TournamentCodeParametersV5 data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TournamentCodeParametersV5 {
         /// Optional list of encrypted puuids in order to validate the players eligible to join the lobby. NOTE: We currently do not enforce participants at the team level, but rather the aggregate of teamOne and teamTwo. We may add the ability to enforce at the team level in the future.
@@ -3670,7 +3670,7 @@ pub mod tournament_v5 {
     }
     /// TournamentCodeV5 data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TournamentCodeV5 {
         /// The tournament code.
@@ -3716,7 +3716,7 @@ pub mod tournament_v5 {
     }
     /// TournamentCodeUpdateParametersV5 data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TournamentCodeUpdateParametersV5 {
         /// Optional list of encrypted puuids in order to validate the players eligible to join the lobby. NOTE: We currently do not enforce participants at the team level, but rather the aggregate of teamOne and teamTwo. We may add the ability to enforce at the team level in the future.
@@ -3738,7 +3738,7 @@ pub mod tournament_v5 {
     }
     /// TournamentGamesV5 data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TournamentGamesV5 {
         #[serde(rename = "winningTeam")]
@@ -3769,7 +3769,7 @@ pub mod tournament_v5 {
     }
     /// TournamentTeamV5 data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TournamentTeamV5 {
         /// Player Unique UUID (Encrypted)
@@ -3778,7 +3778,7 @@ pub mod tournament_v5 {
     }
     /// LobbyEventV5Wrapper data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LobbyEventV5Wrapper {
         #[serde(rename = "eventList")]
@@ -3786,7 +3786,7 @@ pub mod tournament_v5 {
     }
     /// LobbyEventV5 data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LobbyEventV5 {
         /// Timestamp from the event
@@ -3801,7 +3801,7 @@ pub mod tournament_v5 {
     }
     /// ProviderRegistrationParametersV5 data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ProviderRegistrationParametersV5 {
         /// The region in which the provider will be running tournaments.<br>
@@ -3814,7 +3814,7 @@ pub mod tournament_v5 {
     }
     /// TournamentRegistrationParametersV5 data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TournamentRegistrationParametersV5 {
         /// The provider ID to specify the regional registered provider data to associate this tournament.
@@ -3834,7 +3834,7 @@ pub mod tournament_v5 {
 pub mod val_console_match_v1 {
     /// Match data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Match {
         #[serde(rename = "matchInfo")]
@@ -3850,7 +3850,7 @@ pub mod val_console_match_v1 {
     }
     /// MatchInfo data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct MatchInfo {
         #[serde(rename = "matchId")]
@@ -3878,7 +3878,7 @@ pub mod val_console_match_v1 {
     }
     /// Player data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Player {
         #[serde(rename = "puuid")]
@@ -3904,7 +3904,7 @@ pub mod val_console_match_v1 {
     }
     /// PlayerStats data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlayerStats {
         #[serde(rename = "score")]
@@ -3924,7 +3924,7 @@ pub mod val_console_match_v1 {
     }
     /// AbilityCasts data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct AbilityCasts {
         #[serde(rename = "grenadeCasts")]
@@ -3938,7 +3938,7 @@ pub mod val_console_match_v1 {
     }
     /// Coach data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Coach {
         #[serde(rename = "puuid")]
@@ -3948,7 +3948,7 @@ pub mod val_console_match_v1 {
     }
     /// Team data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Team {
         /// This is an arbitrary string. Red and Blue in bomb modes. The puuid of the player in deathmatch.
@@ -3966,7 +3966,7 @@ pub mod val_console_match_v1 {
     }
     /// RoundResult data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct RoundResult {
         #[serde(rename = "roundNum")]
@@ -4004,7 +4004,7 @@ pub mod val_console_match_v1 {
     }
     /// PlayerLocations data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlayerLocations {
         #[serde(rename = "puuid")]
@@ -4016,7 +4016,7 @@ pub mod val_console_match_v1 {
     }
     /// Location data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Location {
         #[serde(rename = "x")]
@@ -4026,7 +4026,7 @@ pub mod val_console_match_v1 {
     }
     /// PlayerRoundStats data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlayerRoundStats {
         #[serde(rename = "puuid")]
@@ -4044,7 +4044,7 @@ pub mod val_console_match_v1 {
     }
     /// Kill data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Kill {
         #[serde(rename = "timeSinceGameStartMillis")]
@@ -4069,7 +4069,7 @@ pub mod val_console_match_v1 {
     }
     /// FinishingDamage data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct FinishingDamage {
         #[serde(rename = "damageType")]
@@ -4081,7 +4081,7 @@ pub mod val_console_match_v1 {
     }
     /// Damage data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Damage {
         /// PUUID
@@ -4098,7 +4098,7 @@ pub mod val_console_match_v1 {
     }
     /// Economy data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Economy {
         #[serde(rename = "loadoutValue")]
@@ -4114,7 +4114,7 @@ pub mod val_console_match_v1 {
     }
     /// Ability data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Ability {
         #[serde(rename = "grenadeEffects")]
@@ -4128,7 +4128,7 @@ pub mod val_console_match_v1 {
     }
     /// Matchlist data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Matchlist {
         #[serde(rename = "puuid")]
@@ -4138,7 +4138,7 @@ pub mod val_console_match_v1 {
     }
     /// MatchlistEntry data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct MatchlistEntry {
         #[serde(rename = "matchId")]
@@ -4150,7 +4150,7 @@ pub mod val_console_match_v1 {
     }
     /// RecentMatches data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct RecentMatches {
         #[serde(rename = "currentTime")]
@@ -4168,7 +4168,7 @@ pub mod val_console_match_v1 {
 pub mod val_console_ranked_v1 {
     /// Leaderboard data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Leaderboard {
         /// The shard for the given leaderboard.
@@ -4185,7 +4185,7 @@ pub mod val_console_ranked_v1 {
     }
     /// Player data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Player {
         /// This field may be omitted if the player has been anonymized.
@@ -4213,7 +4213,7 @@ pub mod val_console_ranked_v1 {
 pub mod val_content_v1 {
     /// Content data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Content {
         #[serde(rename = "version")]
@@ -4255,7 +4255,7 @@ pub mod val_content_v1 {
     }
     /// ContentItem data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ContentItem {
         #[serde(rename = "name")]
@@ -4275,7 +4275,7 @@ pub mod val_content_v1 {
     }
     /// LocalizedNames data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LocalizedNames {
         #[serde(rename = "ar-AE")]
@@ -4320,7 +4320,7 @@ pub mod val_content_v1 {
     }
     /// Act data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Act {
         #[serde(rename = "name")]
@@ -4349,7 +4349,7 @@ pub mod val_content_v1 {
 pub mod val_match_v1 {
     /// Match data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Match {
         #[serde(rename = "matchInfo")]
@@ -4367,7 +4367,7 @@ pub mod val_match_v1 {
     }
     /// MatchInfo data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct MatchInfo {
         #[serde(rename = "matchId")]
@@ -4402,7 +4402,7 @@ pub mod val_match_v1 {
     }
     /// Player data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Player {
         #[serde(rename = "puuid")]
@@ -4433,7 +4433,7 @@ pub mod val_match_v1 {
     }
     /// PlayerStats data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlayerStats {
         #[serde(rename = "score")]
@@ -4454,7 +4454,7 @@ pub mod val_match_v1 {
     }
     /// AbilityCasts data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct AbilityCasts {
         #[serde(rename = "grenadeCasts")]
@@ -4468,7 +4468,7 @@ pub mod val_match_v1 {
     }
     /// Coach data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Coach {
         #[serde(rename = "puuid")]
@@ -4478,7 +4478,7 @@ pub mod val_match_v1 {
     }
     /// Team data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Team {
         /// This is an arbitrary string. Red and Blue in bomb modes. The puuid of the player in deathmatch.
@@ -4496,7 +4496,7 @@ pub mod val_match_v1 {
     }
     /// RoundResult data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct RoundResult {
         #[serde(rename = "roundNum")]
@@ -4540,7 +4540,7 @@ pub mod val_match_v1 {
     }
     /// PlayerLocations data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlayerLocations {
         #[serde(rename = "puuid")]
@@ -4552,7 +4552,7 @@ pub mod val_match_v1 {
     }
     /// Location data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Location {
         #[serde(rename = "x")]
@@ -4562,7 +4562,7 @@ pub mod val_match_v1 {
     }
     /// PlayerRoundStats data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlayerRoundStats {
         #[serde(rename = "puuid")]
@@ -4580,7 +4580,7 @@ pub mod val_match_v1 {
     }
     /// Kill data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Kill {
         #[serde(rename = "timeSinceGameStartMillis")]
@@ -4605,7 +4605,7 @@ pub mod val_match_v1 {
     }
     /// FinishingDamage data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct FinishingDamage {
         #[serde(rename = "damageType")]
@@ -4617,7 +4617,7 @@ pub mod val_match_v1 {
     }
     /// Damage data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Damage {
         /// PUUID
@@ -4634,7 +4634,7 @@ pub mod val_match_v1 {
     }
     /// Economy data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Economy {
         #[serde(rename = "loadoutValue")]
@@ -4650,7 +4650,7 @@ pub mod val_match_v1 {
     }
     /// Ability data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Ability {
         #[serde(rename = "grenadeEffects")]
@@ -4668,7 +4668,7 @@ pub mod val_match_v1 {
     }
     /// Matchlist data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Matchlist {
         #[serde(rename = "puuid")]
@@ -4678,7 +4678,7 @@ pub mod val_match_v1 {
     }
     /// MatchlistEntry data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct MatchlistEntry {
         #[serde(rename = "matchId")]
@@ -4690,7 +4690,7 @@ pub mod val_match_v1 {
     }
     /// RecentMatches data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct RecentMatches {
         #[serde(rename = "currentTime")]
@@ -4708,7 +4708,7 @@ pub mod val_match_v1 {
 pub mod val_ranked_v1 {
     /// Leaderboard data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Leaderboard {
         /// The shard for the given leaderboard.
@@ -4743,7 +4743,7 @@ pub mod val_ranked_v1 {
     }
     /// Player data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Player {
         /// This field may be omitted if the player has been anonymized.
@@ -4770,7 +4770,7 @@ pub mod val_ranked_v1 {
     }
     /// TierDetail data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TierDetail {
         #[serde(rename = "rankedRatingThreshold")]
@@ -4789,7 +4789,7 @@ pub mod val_ranked_v1 {
 pub mod val_status_v1 {
     /// PlatformData data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlatformData {
         #[serde(rename = "id")]
@@ -4805,7 +4805,7 @@ pub mod val_status_v1 {
     }
     /// Status data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Status {
         #[serde(rename = "id")]
@@ -4832,7 +4832,7 @@ pub mod val_status_v1 {
     }
     /// Content data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Content {
         #[serde(rename = "locale")]
@@ -4842,7 +4842,7 @@ pub mod val_status_v1 {
     }
     /// Update data object.
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Update {
         #[serde(rename = "id")]

--- a/riven/src/models.rs
+++ b/riven/src/models.rs
@@ -8,7 +8,7 @@
 ///////////////////////////////////////////////
 
 // http://www.mingweisamuel.com/riotapi-schema/tool/
-// Version 1b37b11075bdad584e6a46a1bdeffa7ad35c4303
+// Version 0ec1ee73a0d4f3138f9cbbe51b2787d41c3d8892
 
 #![allow(missing_docs)]
 
@@ -1416,10 +1416,10 @@ pub mod match_v5 {
         pub x12_assist_streak_count: Option<i32>,
         #[serde(rename = "baronBuffGoldAdvantageOverThreshold")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub baron_buff_gold_advantage_over_threshold: Option<f64>,
+        pub baron_buff_gold_advantage_over_threshold: Option<i32>,
         #[serde(rename = "controlWardTimeCoverageInRiverOrEnemyHalf")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub control_ward_time_coverage_in_river_or_enemy_half: Option<f64>,
+        pub control_ward_time_coverage_in_river_or_enemy_half: Option<f32>,
         #[serde(rename = "earliestBaron")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub earliest_baron: Option<f64>,
@@ -1434,70 +1434,70 @@ pub mod match_v5 {
         pub early_laning_phase_gold_exp_advantage: Option<f64>,
         #[serde(rename = "fasterSupportQuestCompletion")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub faster_support_quest_completion: Option<f64>,
+        pub faster_support_quest_completion: Option<i32>,
         #[serde(rename = "fastestLegendary")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub fastest_legendary: Option<f64>,
         #[serde(rename = "hadAfkTeammate")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub had_afk_teammate: Option<f64>,
+        pub had_afk_teammate: Option<i32>,
         #[serde(rename = "highestChampionDamage")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub highest_champion_damage: Option<f64>,
+        pub highest_champion_damage: Option<i32>,
         #[serde(rename = "highestCrowdControlScore")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub highest_crowd_control_score: Option<f64>,
+        pub highest_crowd_control_score: Option<i32>,
         #[serde(rename = "highestWardKills")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub highest_ward_kills: Option<f64>,
+        pub highest_ward_kills: Option<i32>,
         #[serde(rename = "junglerKillsEarlyJungle")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub jungler_kills_early_jungle: Option<f64>,
+        pub jungler_kills_early_jungle: Option<i32>,
         #[serde(rename = "killsOnLanersEarlyJungleAsJungler")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub kills_on_laners_early_jungle_as_jungler: Option<f64>,
+        pub kills_on_laners_early_jungle_as_jungler: Option<i32>,
         #[serde(rename = "laningPhaseGoldExpAdvantage")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub laning_phase_gold_exp_advantage: Option<f64>,
+        pub laning_phase_gold_exp_advantage: Option<i32>,
         #[serde(rename = "legendaryCount")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub legendary_count: Option<f64>,
+        pub legendary_count: Option<i32>,
         #[serde(rename = "maxCsAdvantageOnLaneOpponent")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub max_cs_advantage_on_lane_opponent: Option<f64>,
+        pub max_cs_advantage_on_lane_opponent: Option<f32>,
         #[serde(rename = "maxLevelLeadLaneOpponent")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub max_level_lead_lane_opponent: Option<f64>,
+        pub max_level_lead_lane_opponent: Option<i32>,
         #[serde(rename = "mostWardsDestroyedOneSweeper")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub most_wards_destroyed_one_sweeper: Option<f64>,
+        pub most_wards_destroyed_one_sweeper: Option<i32>,
         #[serde(rename = "mythicItemUsed")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub mythic_item_used: Option<f64>,
+        pub mythic_item_used: Option<i32>,
         #[serde(rename = "playedChampSelectPosition")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub played_champ_select_position: Option<f64>,
+        pub played_champ_select_position: Option<i32>,
         #[serde(rename = "soloTurretsLategame")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub solo_turrets_lategame: Option<f64>,
+        pub solo_turrets_lategame: Option<i32>,
         #[serde(rename = "takedownsFirst25Minutes")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub takedowns_first25_minutes: Option<f64>,
+        pub takedowns_first25_minutes: Option<i32>,
         #[serde(rename = "teleportTakedowns")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub teleport_takedowns: Option<f64>,
+        pub teleport_takedowns: Option<i32>,
         #[serde(rename = "thirdInhibitorDestroyedTime")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub third_inhibitor_destroyed_time: Option<f64>,
         #[serde(rename = "threeWardsOneSweeperCount")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub three_wards_one_sweeper_count: Option<f64>,
+        pub three_wards_one_sweeper_count: Option<i32>,
         #[serde(rename = "visionScoreAdvantageLaneOpponent")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub vision_score_advantage_lane_opponent: Option<f64>,
+        pub vision_score_advantage_lane_opponent: Option<f32>,
         #[serde(rename = "InfernalScalePickup")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub infernal_scale_pickup: Option<f64>,
+        pub infernal_scale_pickup: Option<i32>,
         #[serde(rename = "fistBumpParticipation")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub fist_bump_participation: Option<i32>,
@@ -1512,7 +1512,7 @@ pub mod match_v5 {
         pub aces_before15_minutes: Option<i32>,
         #[serde(rename = "alliedJungleMonsterKills")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub allied_jungle_monster_kills: Option<f64>,
+        pub allied_jungle_monster_kills: Option<f32>,
         #[serde(rename = "baronTakedowns")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub baron_takedowns: Option<i32>,
@@ -1533,10 +1533,10 @@ pub mod match_v5 {
         pub control_wards_placed: Option<i32>,
         #[serde(rename = "damagePerMinute")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub damage_per_minute: Option<f64>,
+        pub damage_per_minute: Option<f32>,
         #[serde(rename = "damageTakenOnTeamPercentage")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub damage_taken_on_team_percentage: Option<f64>,
+        pub damage_taken_on_team_percentage: Option<f32>,
         #[serde(rename = "dancedWithRiftHerald")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub danced_with_rift_herald: Option<i32>,
@@ -1569,7 +1569,7 @@ pub mod match_v5 {
         pub enemy_champion_immobilizations: Option<i32>,
         #[serde(rename = "enemyJungleMonsterKills")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub enemy_jungle_monster_kills: Option<f64>,
+        pub enemy_jungle_monster_kills: Option<f32>,
         #[serde(rename = "epicMonsterKillsNearEnemyJungler")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub epic_monster_kills_near_enemy_jungler: Option<i32>,
@@ -1596,13 +1596,13 @@ pub mod match_v5 {
         pub full_team_takedown: Option<i32>,
         #[serde(rename = "gameLength")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub game_length: Option<f64>,
+        pub game_length: Option<f32>,
         #[serde(rename = "getTakedownsInAllLanesEarlyJungleAsLaner")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub get_takedowns_in_all_lanes_early_jungle_as_laner: Option<i32>,
         #[serde(rename = "goldPerMinute")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub gold_per_minute: Option<f64>,
+        pub gold_per_minute: Option<f32>,
         #[serde(rename = "hadOpenNexus")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub had_open_nexus: Option<i32>,
@@ -1617,13 +1617,13 @@ pub mod match_v5 {
         pub initial_crab_count: Option<i32>,
         #[serde(rename = "jungleCsBefore10Minutes")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub jungle_cs_before10_minutes: Option<f64>,
+        pub jungle_cs_before10_minutes: Option<f32>,
         #[serde(rename = "junglerTakedownsNearDamagedEpicMonster")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub jungler_takedowns_near_damaged_epic_monster: Option<i32>,
         #[serde(rename = "kda")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub kda: Option<f64>,
+        pub kda: Option<f32>,
         #[serde(rename = "killAfterHiddenWithAlly")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub kill_after_hidden_with_ally: Option<i32>,
@@ -1635,7 +1635,7 @@ pub mod match_v5 {
         pub killing_sprees: Option<i32>,
         #[serde(rename = "killParticipation")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub kill_participation: Option<f64>,
+        pub kill_participation: Option<f32>,
         #[serde(rename = "killsNearEnemyTurret")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub kills_near_enemy_turret: Option<i32>,
@@ -1674,7 +1674,7 @@ pub mod match_v5 {
         pub mejais_full_stack_in_time: Option<i32>,
         #[serde(rename = "moreEnemyJungleThanOpponent")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub more_enemy_jungle_than_opponent: Option<f64>,
+        pub more_enemy_jungle_than_opponent: Option<f32>,
         /// This is an offshoot of the OneStone challenge. The code checks if a spell with the same instance ID does the final point of damage to at least 2 Champions. It doesn't matter if they're enemies, but you cannot hurt your friends.
         #[serde(rename = "multiKillOneSpell")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1762,7 +1762,7 @@ pub mod match_v5 {
         pub swarm_kill_enemy: Option<i32>,
         #[serde(rename = "SWARM_PickupGold")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub swarm_pickup_gold: Option<i32>,
+        pub swarm_pickup_gold: Option<f32>,
         #[serde(rename = "SWARM_ReachLevel50")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub swarm_reach_level50: Option<i32>,
@@ -1810,7 +1810,7 @@ pub mod match_v5 {
         pub team_baron_kills: Option<i32>,
         #[serde(rename = "teamDamagePercentage")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub team_damage_percentage: Option<f64>,
+        pub team_damage_percentage: Option<f32>,
         #[serde(rename = "teamElderDragonKills")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub team_elder_dragon_kills: Option<i32>,
@@ -1841,7 +1841,7 @@ pub mod match_v5 {
         pub unseen_recalls: Option<i32>,
         #[serde(rename = "visionScorePerMinute")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub vision_score_per_minute: Option<f64>,
+        pub vision_score_per_minute: Option<f32>,
         #[serde(rename = "wardsGuarded")]
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub wards_guarded: Option<i32>,

--- a/riven/src/models.rs
+++ b/riven/src/models.rs
@@ -20,29 +20,29 @@
 //! Note: these modules are automatically generated.
 
 /// Data structs used by [`AccountV1`](crate::endpoints::AccountV1).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod account_v1 {
-    /// Account data object.
+    /// `account-v1.AccountDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Account {
         #[serde(rename = "puuid")]
         pub puuid: String,
         /// This field may be excluded from the response if the account doesn't have a gameName.
         #[serde(rename = "gameName")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub game_name: Option<String>,
         /// This field may be excluded from the response if the account doesn't have a tagLine.
         #[serde(rename = "tagLine")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub tag_line: Option<String>,
     }
-    /// ActiveShard data object.
+    /// `account-v1.ActiveShardDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ActiveShard {
         #[serde(rename = "puuid")]
@@ -55,17 +55,17 @@ pub mod account_v1 {
 }
 
 /// Data structs used by [`ChampionMasteryV4`](crate::endpoints::ChampionMasteryV4).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod champion_mastery_v4 {
-    /// ChampionMastery data object.
+    /// `champion-mastery-v4.ChampionMasteryDto` data object.
     /// # Description
     /// This object contains single Champion Mastery information for player and champion combination.
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ChampionMastery {
         /// Player Universal Unique Identifier. Exact length of 78 characters. (Encrypted)
@@ -76,7 +76,7 @@ pub mod champion_mastery_v4 {
         pub champion_points_until_next_level: i64,
         /// Is chest granted for this champion or not in current season.
         #[serde(rename = "chestGranted")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub chest_granted: Option<bool>,
         /// Champion ID for this entry.
         #[serde(rename = "championId")]
@@ -103,16 +103,16 @@ pub mod champion_mastery_v4 {
         #[serde(rename = "tokensEarned")]
         pub tokens_earned: i32,
         #[serde(rename = "milestoneGrades")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub milestone_grades: Option<std::vec::Vec<String>>,
     }
-    /// NextSeasonMilestones data object.
+    /// `champion-mastery-v4.NextSeasonMilestonesDto` data object.
     /// # Description
     /// This object contains required next season milestone information.
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct NextSeasonMilestones {
         #[serde(rename = "requireGradeCounts")]
@@ -125,18 +125,18 @@ pub mod champion_mastery_v4 {
         pub bonus: bool,
         /// Reward configuration.
         #[serde(rename = "rewardConfig")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub reward_config: Option<RewardConfig>,
         #[serde(rename = "totalGamesRequires")]
         pub total_games_requires: i32,
     }
-    /// RewardConfig data object.
+    /// `champion-mastery-v4.RewardConfigDto` data object.
     /// # Description
     /// This object contains required reward config information.
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct RewardConfig {
         /// Reward value
@@ -152,13 +152,13 @@ pub mod champion_mastery_v4 {
 }
 
 /// Data structs used by [`ChampionV3`](crate::endpoints::ChampionV3).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod champion_v3 {
-    /// ChampionInfo data object.
+    /// `champion-v3.ChampionInfo` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ChampionInfo {
         #[serde(rename = "maxNewPlayerLevel")]
@@ -171,13 +171,13 @@ pub mod champion_v3 {
 }
 
 /// Data structs used by [`ClashV1`](crate::endpoints::ClashV1).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod clash_v1 {
-    /// Player data object.
+    /// `clash-v1.PlayerDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Player {
         #[serde(rename = "summonerId")]
@@ -185,7 +185,7 @@ pub mod clash_v1 {
         #[serde(rename = "puuid")]
         pub puuid: String,
         #[serde(rename = "teamId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub team_id: Option<String>,
         /// (Legal values:  UNSELECTED,  FILL,  TOP,  JUNGLE,  MIDDLE,  BOTTOM,  UTILITY)
         #[serde(rename = "position")]
@@ -194,9 +194,9 @@ pub mod clash_v1 {
         #[serde(rename = "role")]
         pub role: String,
     }
-    /// Team data object.
+    /// `clash-v1.TeamDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Team {
         #[serde(rename = "id")]
@@ -218,9 +218,9 @@ pub mod clash_v1 {
         #[serde(rename = "players")]
         pub players: std::vec::Vec<Player>,
     }
-    /// Tournament data object.
+    /// `clash-v1.TournamentDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Tournament {
         #[serde(rename = "id")]
@@ -235,9 +235,9 @@ pub mod clash_v1 {
         #[serde(rename = "schedule")]
         pub schedule: std::vec::Vec<TournamentPhase>,
     }
-    /// TournamentPhase data object.
+    /// `clash-v1.TournamentPhaseDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TournamentPhase {
         #[serde(rename = "id")]
@@ -252,13 +252,13 @@ pub mod clash_v1 {
 }
 
 /// Data structs used by [`LeagueExpV4`](crate::endpoints::LeagueExpV4).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod league_exp_v4 {
-    /// LeagueEntry data object.
+    /// `league-exp-v4.LeagueEntryDTO` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LeagueEntry {
         #[serde(rename = "leagueId")]
@@ -293,12 +293,12 @@ pub mod league_exp_v4 {
         #[serde(rename = "inactive")]
         pub inactive: bool,
         #[serde(rename = "miniSeries")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub mini_series: Option<MiniSeries>,
     }
-    /// MiniSeries data object.
+    /// `league-exp-v4.MiniSeriesDTO` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct MiniSeries {
         #[serde(rename = "losses")]
@@ -313,32 +313,32 @@ pub mod league_exp_v4 {
 }
 
 /// Data structs used by [`LeagueV4`](crate::endpoints::LeagueV4).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod league_v4 {
-    /// LeagueList data object.
+    /// `league-v4.LeagueListDTO` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LeagueList {
         #[serde(rename = "leagueId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub league_id: Option<String>,
         #[serde(rename = "entries")]
         pub entries: std::vec::Vec<LeagueItem>,
         #[serde(rename = "tier")]
         pub tier: crate::consts::Tier,
         #[serde(rename = "name")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub name: Option<String>,
         #[serde(rename = "queue")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub queue: Option<crate::consts::QueueType>,
     }
-    /// LeagueItem data object.
+    /// `league-v4.LeagueItemDTO` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LeagueItem {
         #[serde(rename = "freshBlood")]
@@ -347,7 +347,7 @@ pub mod league_v4 {
         #[serde(rename = "wins")]
         pub wins: i32,
         #[serde(rename = "miniSeries")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub mini_series: Option<MiniSeries>,
         #[serde(rename = "inactive")]
         pub inactive: bool,
@@ -369,9 +369,9 @@ pub mod league_v4 {
         #[serde(rename = "puuid")]
         pub puuid: String,
     }
-    /// MiniSeries data object.
+    /// `league-v4.MiniSeriesDTO` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct MiniSeries {
         #[serde(rename = "losses")]
@@ -383,13 +383,13 @@ pub mod league_v4 {
         #[serde(rename = "wins")]
         pub wins: i32,
     }
-    /// LeagueEntry data object.
+    /// `league-v4.LeagueEntryDTO` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LeagueEntry {
         #[serde(rename = "leagueId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub league_id: Option<String>,
         /// Player's encrypted summonerId.
         #[serde(rename = "summonerId")]
@@ -400,11 +400,11 @@ pub mod league_v4 {
         #[serde(rename = "queueType")]
         pub queue_type: crate::consts::QueueType,
         #[serde(rename = "tier")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub tier: Option<crate::consts::Tier>,
         /// The player's division within a tier.
         #[serde(rename = "rank")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub rank: Option<crate::consts::Division>,
         #[serde(rename = "leaguePoints")]
         pub league_points: i32,
@@ -423,19 +423,19 @@ pub mod league_v4 {
         #[serde(rename = "inactive")]
         pub inactive: bool,
         #[serde(rename = "miniSeries")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub mini_series: Option<MiniSeries>,
     }
 }
 
 /// Data structs used by [`LolChallengesV1`](crate::endpoints::LolChallengesV1).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod lol_challenges_v1 {
-    /// ChallengeConfigInfo data object.
+    /// `lol-challenges-v1.ChallengeConfigInfoDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ChallengeConfigInfo {
         #[serde(rename = "id")]
@@ -447,20 +447,20 @@ pub mod lol_challenges_v1 {
         pub state: String,
         /// LIFETIME - stats are incremented without reset, SEASON - stats are accumulated by season and reset at the beginning of new season
         #[serde(rename = "tracking")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub tracking: Option<String>,
         #[serde(rename = "startTimestamp")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub start_timestamp: Option<i64>,
         #[serde(rename = "endTimestamp")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub end_timestamp: Option<i64>,
         #[serde(rename = "leaderboard")]
         pub leaderboard: bool,
         #[serde(rename = "thresholds")]
         pub thresholds: std::collections::HashMap<String, f64>,
     }
-    /// State data object.
+    /// `lol-challenges-v1.State` data object.
     /// # Description
     /// DISABLED - not visible and not calculated,<br>
     /// HIDDEN - not visible, but calculated,<br>
@@ -469,24 +469,24 @@ pub mod lol_challenges_v1 {
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct State {
     }
-    /// Tracking data object.
+    /// `lol-challenges-v1.Tracking` data object.
     /// # Description
     /// LIFETIME - stats are incremented without reset,<br>
     /// SEASON - stats are accumulated by season and reset at the beginning of new season
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Tracking {
     }
-    /// ApexPlayerInfo data object.
+    /// `lol-challenges-v1.ApexPlayerInfoDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ApexPlayerInfo {
         #[serde(rename = "puuid")]
@@ -496,7 +496,7 @@ pub mod lol_challenges_v1 {
         #[serde(rename = "position")]
         pub position: i32,
     }
-    /// Level data object.
+    /// `lol-challenges-v1.Level` data object.
     /// # Description
     /// 0 NONE,<br>
     /// 1 IRON,<br>
@@ -511,13 +511,13 @@ pub mod lol_challenges_v1 {
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Level {
     }
-    /// PlayerInfo data object.
+    /// `lol-challenges-v1.PlayerInfoDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlayerInfo {
         #[serde(rename = "challenges")]
@@ -529,9 +529,9 @@ pub mod lol_challenges_v1 {
         #[serde(rename = "categoryPoints")]
         pub category_points: std::collections::HashMap<String, ChallengePoints>,
     }
-    /// ChallengeInfo data object.
+    /// `lol-challenges-v1.ChallengeInfo` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ChallengeInfo {
         #[serde(rename = "challengeId")]
@@ -543,39 +543,39 @@ pub mod lol_challenges_v1 {
         #[serde(rename = "value")]
         pub value: f64,
         #[serde(rename = "achievedTime")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub achieved_time: Option<i64>,
         #[serde(rename = "position")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub position: Option<i64>,
         #[serde(rename = "playersInLevel")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub players_in_level: Option<i64>,
     }
-    /// PlayerClientPreferences data object.
+    /// `lol-challenges-v1.PlayerClientPreferences` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlayerClientPreferences {
         #[serde(rename = "bannerAccent")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub banner_accent: Option<String>,
         #[serde(rename = "title")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub title: Option<String>,
         #[serde(rename = "challengeIds")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub challenge_ids: Option<std::vec::Vec<i64>>,
         #[serde(rename = "crestBorder")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub crest_border: Option<String>,
         #[serde(rename = "prestigeCrestBorderLevel")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub prestige_crest_border_level: Option<i32>,
     }
-    /// ChallengePoints data object.
+    /// `lol-challenges-v1.ChallengePoints` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ChallengePoints {
         #[serde(rename = "level")]
@@ -585,46 +585,46 @@ pub mod lol_challenges_v1 {
         #[serde(rename = "max")]
         pub max: i64,
         #[serde(rename = "percentile")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub percentile: Option<f64>,
     }
 }
 
 /// Data structs used by [`LolRsoMatchV1`](crate::endpoints::LolRsoMatchV1).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod lol_rso_match_v1 {
-    /// Match data object.
+    /// `lol-rso-match-v1.MatchDto` data object.
     /// # Description
     /// UNKNOWN TYPE.
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Match {
     }
-    /// Timeline data object.
+    /// `lol-rso-match-v1.TimelineDto` data object.
     /// # Description
     /// UNKNOWN TYPE.
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Timeline {
     }
 }
 
 /// Data structs used by [`LolStatusV4`](crate::endpoints::LolStatusV4).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod lol_status_v4 {
-    /// PlatformData data object.
+    /// `lol-status-v4.PlatformDataDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlatformData {
         #[serde(rename = "id")]
@@ -638,20 +638,20 @@ pub mod lol_status_v4 {
         #[serde(rename = "incidents")]
         pub incidents: std::vec::Vec<Status>,
     }
-    /// Status data object.
+    /// `lol-status-v4.StatusDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Status {
         #[serde(rename = "id")]
         pub id: i32,
         /// (Legal values:  scheduled,  in_progress,  complete)
         #[serde(rename = "maintenance_status")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub maintenance_status: Option<String>,
         /// (Legal values:  info,  warning,  critical)
         #[serde(rename = "incident_severity")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub incident_severity: Option<String>,
         #[serde(rename = "titles")]
         pub titles: std::vec::Vec<Content>,
@@ -660,18 +660,18 @@ pub mod lol_status_v4 {
         #[serde(rename = "created_at")]
         pub created_at: String,
         #[serde(rename = "archive_at")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub archive_at: Option<String>,
         #[serde(rename = "updated_at")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub updated_at: Option<String>,
         /// (Legal values: windows, macos, android, ios, ps4, xbone, switch)
         #[serde(rename = "platforms")]
         pub platforms: std::vec::Vec<String>,
     }
-    /// Content data object.
+    /// `lol-status-v4.ContentDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Content {
         #[serde(rename = "locale")]
@@ -679,9 +679,9 @@ pub mod lol_status_v4 {
         #[serde(rename = "content")]
         pub content: String,
     }
-    /// Update data object.
+    /// `lol-status-v4.UpdateDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Update {
         #[serde(rename = "id")]
@@ -703,13 +703,13 @@ pub mod lol_status_v4 {
 }
 
 /// Data structs used by [`LorDeckV1`](crate::endpoints::LorDeckV1).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod lor_deck_v1 {
-    /// Deck data object.
+    /// `lor-deck-v1.DeckDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Deck {
         #[serde(rename = "id")]
@@ -719,9 +719,9 @@ pub mod lor_deck_v1 {
         #[serde(rename = "code")]
         pub code: String,
     }
-    /// NewDeck data object.
+    /// `lor-deck-v1.NewDeckDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct NewDeck {
         #[serde(rename = "name")]
@@ -732,13 +732,13 @@ pub mod lor_deck_v1 {
 }
 
 /// Data structs used by [`LorInventoryV1`](crate::endpoints::LorInventoryV1).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod lor_inventory_v1 {
-    /// Card data object.
+    /// `lor-inventory-v1.CardDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Card {
         #[serde(rename = "code")]
@@ -749,13 +749,13 @@ pub mod lor_inventory_v1 {
 }
 
 /// Data structs used by [`LorMatchV1`](crate::endpoints::LorMatchV1).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod lor_match_v1 {
-    /// Match data object.
+    /// `lor-match-v1.MatchDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Match {
         /// Match metadata.
@@ -765,9 +765,9 @@ pub mod lor_match_v1 {
         #[serde(rename = "info")]
         pub info: Info,
     }
-    /// Metadata data object.
+    /// `lor-match-v1.MetadataDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Metadata {
         /// Match data version.
@@ -780,9 +780,9 @@ pub mod lor_match_v1 {
         #[serde(rename = "participants")]
         pub participants: std::vec::Vec<String>,
     }
-    /// Info data object.
+    /// `lor-match-v1.InfoDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Info {
         /// (Legal values:  Constructed,  Expeditions,  Tutorial)
@@ -804,9 +804,9 @@ pub mod lor_match_v1 {
         #[serde(rename = "total_turn_count")]
         pub total_turn_count: i32,
     }
-    /// Player data object.
+    /// `lor-match-v1.PlayerDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Player {
         #[serde(rename = "puuid")]
@@ -827,22 +827,22 @@ pub mod lor_match_v1 {
 }
 
 /// Data structs used by [`LorRankedV1`](crate::endpoints::LorRankedV1).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod lor_ranked_v1 {
-    /// Leaderboard data object.
+    /// `lor-ranked-v1.LeaderboardDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Leaderboard {
         /// A list of players in Master tier.
         #[serde(rename = "players")]
         pub players: std::vec::Vec<Player>,
     }
-    /// Player data object.
+    /// `lor-ranked-v1.PlayerDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Player {
         #[serde(rename = "name")]
@@ -856,13 +856,13 @@ pub mod lor_ranked_v1 {
 }
 
 /// Data structs used by [`LorStatusV1`](crate::endpoints::LorStatusV1).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod lor_status_v1 {
-    /// PlatformData data object.
+    /// `lor-status-v1.PlatformDataDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlatformData {
         #[serde(rename = "id")]
@@ -876,9 +876,9 @@ pub mod lor_status_v1 {
         #[serde(rename = "incidents")]
         pub incidents: std::vec::Vec<Status>,
     }
-    /// Status data object.
+    /// `lor-status-v1.StatusDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Status {
         #[serde(rename = "id")]
@@ -903,9 +903,9 @@ pub mod lor_status_v1 {
         #[serde(rename = "platforms")]
         pub platforms: std::vec::Vec<String>,
     }
-    /// Content data object.
+    /// `lor-status-v1.ContentDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Content {
         #[serde(rename = "locale")]
@@ -913,9 +913,9 @@ pub mod lor_status_v1 {
         #[serde(rename = "content")]
         pub content: String,
     }
-    /// Update data object.
+    /// `lor-status-v1.UpdateDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Update {
         #[serde(rename = "id")]
@@ -937,13 +937,13 @@ pub mod lor_status_v1 {
 }
 
 /// Data structs used by [`MatchV5`](crate::endpoints::MatchV5).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod match_v5 {
-    /// Match data object.
+    /// `match-v5.MatchDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Match {
         /// Match metadata.
@@ -953,9 +953,9 @@ pub mod match_v5 {
         #[serde(rename = "info")]
         pub info: Info,
     }
-    /// Metadata data object.
+    /// `match-v5.MetadataDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Metadata {
         /// Match data version.
@@ -968,14 +968,14 @@ pub mod match_v5 {
         #[serde(rename = "participants")]
         pub participants: std::vec::Vec<String>,
     }
-    /// Info data object.
+    /// `match-v5.InfoDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Info {
         /// Refer to indicate if the game ended in termination.
         #[serde(rename = "endOfGameResult")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub end_of_game_result: Option<String>,
         /// Unix timestamp for when the game is created on the game server (i.e., the loading screen).
         #[serde(rename = "gameCreation")]
@@ -985,7 +985,7 @@ pub mod match_v5 {
         pub game_duration: i64,
         /// Unix timestamp for when match ends on the game server. This timestamp can occasionally be significantly longer than when the match "ends". The most reliable way of determining the timestamp for the end of the match would be to add the max time played of any participant to the gameStartTimestamp. This field was added to match-v5 in patch 11.20 on Oct 5th, 2021.
         #[serde(rename = "gameEndTimestamp")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub game_end_timestamp: Option<i64>,
         #[serde(rename = "gameId")]
         pub game_id: i64,
@@ -1021,21 +1021,21 @@ pub mod match_v5 {
         pub teams: std::vec::Vec<Team>,
         /// Tournament code used to generate the match. This field was added to match-v5 in patch 11.13 on June 23rd, 2021.
         #[serde(rename = "tournamentCode")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub tournament_code: Option<String>,
     }
-    /// Participant data object.
+    /// `match-v5.ParticipantDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Participant {
         /// Yellow crossed swords
         #[serde(rename = "allInPings")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub all_in_pings: Option<i32>,
         /// Green flag
         #[serde(rename = "assistMePings")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub assist_me_pings: Option<i32>,
         #[serde(rename = "assists")]
         pub assists: i32,
@@ -1059,7 +1059,7 @@ pub mod match_v5 {
         pub champion_name: String,
         /// Blue generic ping (ALT+click)
         #[serde(rename = "commandPings")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub command_pings: Option<i32>,
         /// This field is currently only utilized for Kayn's transformations. (Legal values: 0 - None, 1 - Slayer, 2 - Assassin)
         #[serde(rename = "championTransform")]
@@ -1067,10 +1067,10 @@ pub mod match_v5 {
         #[serde(rename = "consumablesPurchased")]
         pub consumables_purchased: i32,
         #[serde(rename = "challenges")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub challenges: Option<Challenges>,
         #[serde(rename = "damageDealtToBuildings")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub damage_dealt_to_buildings: Option<i32>,
         #[serde(rename = "damageDealtToObjectives")]
         pub damage_dealt_to_objectives: i32,
@@ -1087,15 +1087,15 @@ pub mod match_v5 {
         #[serde(rename = "dragonKills")]
         pub dragon_kills: i32,
         #[serde(rename = "eligibleForProgression")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub eligible_for_progression: Option<bool>,
         /// Yellow questionmark
         #[serde(rename = "enemyMissingPings")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub enemy_missing_pings: Option<i32>,
         /// Red eyeball
         #[serde(rename = "enemyVisionPings")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub enemy_vision_pings: Option<i32>,
         #[serde(rename = "firstBloodAssist")]
         pub first_blood_assist: bool,
@@ -1111,11 +1111,11 @@ pub mod match_v5 {
         #[serde(rename = "gameEndedInSurrender")]
         pub game_ended_in_surrender: bool,
         #[serde(rename = "holdPings")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub hold_pings: Option<i32>,
         /// Yellow circle with horizontal line
         #[serde(rename = "getBackPings")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub get_back_pings: Option<i32>,
         #[serde(rename = "goldEarned")]
         pub gold_earned: i32,
@@ -1127,10 +1127,10 @@ pub mod match_v5 {
         #[serde(rename = "inhibitorKills")]
         pub inhibitor_kills: i32,
         #[serde(rename = "inhibitorTakedowns")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub inhibitor_takedowns: Option<i32>,
         #[serde(rename = "inhibitorsLost")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub inhibitors_lost: Option<i32>,
         #[serde(rename = "item0")]
         pub item0: i32,
@@ -1169,22 +1169,22 @@ pub mod match_v5 {
         #[serde(rename = "magicDamageTaken")]
         pub magic_damage_taken: i32,
         #[serde(rename = "missions")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub missions: Option<Missions>,
         /// neutralMinionsKilled = mNeutralMinionsKilled, which is incremented on kills of kPet and kJungleMonster
         #[serde(rename = "neutralMinionsKilled")]
         pub neutral_minions_killed: i32,
         /// Green ward
         #[serde(rename = "needVisionPings")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub need_vision_pings: Option<i32>,
         #[serde(rename = "nexusKills")]
         pub nexus_kills: i32,
         #[serde(rename = "nexusTakedowns")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub nexus_takedowns: Option<i32>,
         #[serde(rename = "nexusLost")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub nexus_lost: Option<i32>,
         #[serde(rename = "objectivesStolen")]
         pub objectives_stolen: i32,
@@ -1192,45 +1192,45 @@ pub mod match_v5 {
         pub objectives_stolen_assists: i32,
         /// Blue arrow pointing at ground
         #[serde(rename = "onMyWayPings")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub on_my_way_pings: Option<i32>,
         #[serde(rename = "participantId")]
         pub participant_id: i32,
         #[serde(rename = "playerScore0", alias = "PlayerScore0")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score0: Option<f32>,
         #[serde(rename = "playerScore1", alias = "PlayerScore1")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score1: Option<f32>,
         #[serde(rename = "playerScore2", alias = "PlayerScore2")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score2: Option<f32>,
         #[serde(rename = "playerScore3", alias = "PlayerScore3")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score3: Option<f32>,
         #[serde(rename = "playerScore4", alias = "PlayerScore4")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score4: Option<f32>,
         #[serde(rename = "playerScore5", alias = "PlayerScore5")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score5: Option<f32>,
         #[serde(rename = "playerScore6", alias = "PlayerScore6")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score6: Option<f32>,
         #[serde(rename = "playerScore7", alias = "PlayerScore7")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score7: Option<f32>,
         #[serde(rename = "playerScore8", alias = "PlayerScore8")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score8: Option<f32>,
         #[serde(rename = "playerScore9", alias = "PlayerScore9")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score9: Option<f32>,
         #[serde(rename = "playerScore10", alias = "PlayerScore10")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score10: Option<f32>,
         #[serde(rename = "playerScore11", alias = "PlayerScore11")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score11: Option<f32>,
         #[serde(rename = "pentaKills")]
         pub penta_kills: i32,
@@ -1243,26 +1243,26 @@ pub mod match_v5 {
         #[serde(rename = "physicalDamageTaken")]
         pub physical_damage_taken: i32,
         #[serde(rename = "placement")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub placement: Option<i32>,
         #[serde(rename = "playerAugment1")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_augment1: Option<i32>,
         #[serde(rename = "playerAugment2")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_augment2: Option<i32>,
         #[serde(rename = "playerAugment3")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_augment3: Option<i32>,
         #[serde(rename = "playerAugment4")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_augment4: Option<i32>,
         #[serde(rename = "playerSubteamId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_subteam_id: Option<i32>,
         /// Green minion
         #[serde(rename = "pushPings")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub push_pings: Option<i32>,
         #[serde(rename = "profileIcon")]
         pub profile_icon: i32,
@@ -1271,10 +1271,10 @@ pub mod match_v5 {
         #[serde(rename = "quadraKills")]
         pub quadra_kills: i32,
         #[serde(rename = "riotIdGameName")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub riot_id_game_name: Option<String>,
         #[serde(rename = "riotIdTagline")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub riot_id_tagline: Option<String>,
         #[serde(rename = "role")]
         pub role: String,
@@ -1289,7 +1289,7 @@ pub mod match_v5 {
         #[serde(rename = "spell4Casts")]
         pub spell4_casts: i32,
         #[serde(rename = "subteamPlacement")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub subteam_placement: Option<i32>,
         #[serde(rename = "summoner1Casts")]
         pub summoner1_casts: i32,
@@ -1317,7 +1317,7 @@ pub mod match_v5 {
         #[serde(rename = "timePlayed")]
         pub time_played: i32,
         #[serde(rename = "totalAllyJungleMinionsKilled")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub total_ally_jungle_minions_killed: Option<i32>,
         #[serde(rename = "totalDamageDealt")]
         pub total_damage_dealt: i32,
@@ -1328,7 +1328,7 @@ pub mod match_v5 {
         #[serde(rename = "totalDamageTaken")]
         pub total_damage_taken: i32,
         #[serde(rename = "totalEnemyJungleMinionsKilled")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub total_enemy_jungle_minions_killed: Option<i32>,
         /// Whenever positive health is applied (which translates to all heals in the game but not things like regeneration), totalHeal is incremented by the amount of health received. This includes healing enemies, jungle monsters, yourself, etc
         #[serde(rename = "totalHeal")]
@@ -1356,17 +1356,17 @@ pub mod match_v5 {
         #[serde(rename = "turretKills")]
         pub turret_kills: i32,
         #[serde(rename = "turretTakedowns")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub turret_takedowns: Option<i32>,
         #[serde(rename = "turretsLost")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub turrets_lost: Option<i32>,
         #[serde(rename = "unrealKills")]
         pub unreal_kills: i32,
         #[serde(rename = "visionScore")]
         pub vision_score: i32,
         #[serde(rename = "visionClearedPings")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub vision_cleared_pings: Option<i32>,
         #[serde(rename = "visionWardsBoughtInGame")]
         pub vision_wards_bought_in_game: i32,
@@ -1377,533 +1377,533 @@ pub mod match_v5 {
         #[serde(rename = "win")]
         pub win: bool,
         #[serde(rename = "baitPings")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub bait_pings: Option<i32>,
         /// https://github.com/RiotGames/developer-relations/issues/870
         #[serde(rename = "dangerPings")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub danger_pings: Option<i32>,
         /// https://github.com/RiotGames/developer-relations/issues/814
         #[serde(rename = "basicPings")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub basic_pings: Option<i32>,
         #[serde(rename = "playerAugment5")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_augment5: Option<i32>,
         #[serde(rename = "playerAugment6")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_augment6: Option<i32>,
         /// Deprecated, use `riotIdGameName`. This field name was briefly used instead of `riotIdGameName`, prior to patch 14.5.
         #[serde(rename = "riotIdName")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub riot_id_name: Option<String>,
         /// https://github.com/RiotGames/developer-relations/issues/814
         #[serde(rename = "retreatPings")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub retreat_pings: Option<i32>,
     }
-    /// Challenges data object.
+    /// `match-v5.ChallengesDto` data object.
     /// # Description
     /// Challenges DTO
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Challenges {
         #[serde(rename = "12AssistStreakCount")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub x12_assist_streak_count: Option<i32>,
         #[serde(rename = "baronBuffGoldAdvantageOverThreshold")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub baron_buff_gold_advantage_over_threshold: Option<f64>,
         #[serde(rename = "controlWardTimeCoverageInRiverOrEnemyHalf")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub control_ward_time_coverage_in_river_or_enemy_half: Option<f64>,
         #[serde(rename = "earliestBaron")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub earliest_baron: Option<f64>,
         #[serde(rename = "earliestDragonTakedown")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub earliest_dragon_takedown: Option<f64>,
         #[serde(rename = "earliestElderDragon")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub earliest_elder_dragon: Option<f64>,
         #[serde(rename = "earlyLaningPhaseGoldExpAdvantage")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub early_laning_phase_gold_exp_advantage: Option<f64>,
         #[serde(rename = "fasterSupportQuestCompletion")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub faster_support_quest_completion: Option<f64>,
         #[serde(rename = "fastestLegendary")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub fastest_legendary: Option<f64>,
         #[serde(rename = "hadAfkTeammate")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub had_afk_teammate: Option<f64>,
         #[serde(rename = "highestChampionDamage")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub highest_champion_damage: Option<f64>,
         #[serde(rename = "highestCrowdControlScore")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub highest_crowd_control_score: Option<f64>,
         #[serde(rename = "highestWardKills")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub highest_ward_kills: Option<f64>,
         #[serde(rename = "junglerKillsEarlyJungle")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub jungler_kills_early_jungle: Option<f64>,
         #[serde(rename = "killsOnLanersEarlyJungleAsJungler")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub kills_on_laners_early_jungle_as_jungler: Option<f64>,
         #[serde(rename = "laningPhaseGoldExpAdvantage")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub laning_phase_gold_exp_advantage: Option<f64>,
         #[serde(rename = "legendaryCount")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub legendary_count: Option<f64>,
         #[serde(rename = "maxCsAdvantageOnLaneOpponent")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub max_cs_advantage_on_lane_opponent: Option<f64>,
         #[serde(rename = "maxLevelLeadLaneOpponent")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub max_level_lead_lane_opponent: Option<f64>,
         #[serde(rename = "mostWardsDestroyedOneSweeper")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub most_wards_destroyed_one_sweeper: Option<f64>,
         #[serde(rename = "mythicItemUsed")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub mythic_item_used: Option<f64>,
         #[serde(rename = "playedChampSelectPosition")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub played_champ_select_position: Option<f64>,
         #[serde(rename = "soloTurretsLategame")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub solo_turrets_lategame: Option<f64>,
         #[serde(rename = "takedownsFirst25Minutes")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub takedowns_first25_minutes: Option<f64>,
         #[serde(rename = "teleportTakedowns")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub teleport_takedowns: Option<f64>,
         #[serde(rename = "thirdInhibitorDestroyedTime")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub third_inhibitor_destroyed_time: Option<f64>,
         #[serde(rename = "threeWardsOneSweeperCount")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub three_wards_one_sweeper_count: Option<f64>,
         #[serde(rename = "visionScoreAdvantageLaneOpponent")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub vision_score_advantage_lane_opponent: Option<f64>,
         #[serde(rename = "InfernalScalePickup")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub infernal_scale_pickup: Option<f64>,
         #[serde(rename = "fistBumpParticipation")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub fist_bump_participation: Option<i32>,
         #[serde(rename = "voidMonsterKill")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub void_monster_kill: Option<i32>,
         #[serde(rename = "abilityUses")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub ability_uses: Option<i32>,
         #[serde(rename = "acesBefore15Minutes")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub aces_before15_minutes: Option<i32>,
         #[serde(rename = "alliedJungleMonsterKills")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub allied_jungle_monster_kills: Option<f64>,
         #[serde(rename = "baronTakedowns")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub baron_takedowns: Option<i32>,
         #[serde(rename = "blastConeOppositeOpponentCount")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub blast_cone_opposite_opponent_count: Option<i32>,
         #[serde(rename = "bountyGold")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub bounty_gold: Option<f64>,
         #[serde(rename = "buffsStolen")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub buffs_stolen: Option<i32>,
         #[serde(rename = "completeSupportQuestInTime")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub complete_support_quest_in_time: Option<i32>,
         #[serde(rename = "controlWardsPlaced")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub control_wards_placed: Option<i32>,
         #[serde(rename = "damagePerMinute")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub damage_per_minute: Option<f64>,
         #[serde(rename = "damageTakenOnTeamPercentage")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub damage_taken_on_team_percentage: Option<f64>,
         #[serde(rename = "dancedWithRiftHerald")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub danced_with_rift_herald: Option<i32>,
         #[serde(rename = "deathsByEnemyChamps")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub deaths_by_enemy_champs: Option<i32>,
         #[serde(rename = "dodgeSkillShotsSmallWindow")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub dodge_skill_shots_small_window: Option<i32>,
         #[serde(rename = "doubleAces")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub double_aces: Option<i32>,
         #[serde(rename = "dragonTakedowns")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub dragon_takedowns: Option<i32>,
         #[serde(rename = "legendaryItemUsed")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub legendary_item_used: Option<std::vec::Vec<i32>>,
         #[serde(rename = "effectiveHealAndShielding")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub effective_heal_and_shielding: Option<f32>,
         #[serde(rename = "elderDragonKillsWithOpposingSoul")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub elder_dragon_kills_with_opposing_soul: Option<i32>,
         #[serde(rename = "elderDragonMultikills")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub elder_dragon_multikills: Option<i32>,
         #[serde(rename = "enemyChampionImmobilizations")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub enemy_champion_immobilizations: Option<i32>,
         #[serde(rename = "enemyJungleMonsterKills")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub enemy_jungle_monster_kills: Option<f64>,
         #[serde(rename = "epicMonsterKillsNearEnemyJungler")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub epic_monster_kills_near_enemy_jungler: Option<i32>,
         #[serde(rename = "epicMonsterKillsWithin30SecondsOfSpawn")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub epic_monster_kills_within30_seconds_of_spawn: Option<i32>,
         #[serde(rename = "epicMonsterSteals")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub epic_monster_steals: Option<i32>,
         #[serde(rename = "epicMonsterStolenWithoutSmite")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub epic_monster_stolen_without_smite: Option<i32>,
         #[serde(rename = "firstTurretKilled")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub first_turret_killed: Option<f64>,
         #[serde(rename = "firstTurretKilledTime")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub first_turret_killed_time: Option<f32>,
         #[serde(rename = "flawlessAces")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub flawless_aces: Option<i32>,
         #[serde(rename = "fullTeamTakedown")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub full_team_takedown: Option<i32>,
         #[serde(rename = "gameLength")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub game_length: Option<f64>,
         #[serde(rename = "getTakedownsInAllLanesEarlyJungleAsLaner")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub get_takedowns_in_all_lanes_early_jungle_as_laner: Option<i32>,
         #[serde(rename = "goldPerMinute")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub gold_per_minute: Option<f64>,
         #[serde(rename = "hadOpenNexus")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub had_open_nexus: Option<i32>,
         #[serde(rename = "immobilizeAndKillWithAlly")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub immobilize_and_kill_with_ally: Option<i32>,
         #[serde(rename = "initialBuffCount")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub initial_buff_count: Option<i32>,
         #[serde(rename = "initialCrabCount")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub initial_crab_count: Option<i32>,
         #[serde(rename = "jungleCsBefore10Minutes")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub jungle_cs_before10_minutes: Option<f64>,
         #[serde(rename = "junglerTakedownsNearDamagedEpicMonster")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub jungler_takedowns_near_damaged_epic_monster: Option<i32>,
         #[serde(rename = "kda")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub kda: Option<f64>,
         #[serde(rename = "killAfterHiddenWithAlly")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub kill_after_hidden_with_ally: Option<i32>,
         #[serde(rename = "killedChampTookFullTeamDamageSurvived")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub killed_champ_took_full_team_damage_survived: Option<i32>,
         #[serde(rename = "killingSprees")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub killing_sprees: Option<i32>,
         #[serde(rename = "killParticipation")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub kill_participation: Option<f64>,
         #[serde(rename = "killsNearEnemyTurret")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub kills_near_enemy_turret: Option<i32>,
         #[serde(rename = "killsOnOtherLanesEarlyJungleAsLaner")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub kills_on_other_lanes_early_jungle_as_laner: Option<i32>,
         #[serde(rename = "killsOnRecentlyHealedByAramPack")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub kills_on_recently_healed_by_aram_pack: Option<i32>,
         #[serde(rename = "killsUnderOwnTurret")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub kills_under_own_turret: Option<i32>,
         #[serde(rename = "killsWithHelpFromEpicMonster")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub kills_with_help_from_epic_monster: Option<i32>,
         #[serde(rename = "knockEnemyIntoTeamAndKill")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub knock_enemy_into_team_and_kill: Option<i32>,
         #[serde(rename = "kTurretsDestroyedBeforePlatesFall")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub k_turrets_destroyed_before_plates_fall: Option<i32>,
         #[serde(rename = "landSkillShotsEarlyGame")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub land_skill_shots_early_game: Option<i32>,
         #[serde(rename = "laneMinionsFirst10Minutes")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub lane_minions_first10_minutes: Option<i32>,
         #[serde(rename = "lostAnInhibitor")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub lost_an_inhibitor: Option<i32>,
         #[serde(rename = "maxKillDeficit")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub max_kill_deficit: Option<i32>,
         #[serde(rename = "mejaisFullStackInTime")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub mejais_full_stack_in_time: Option<i32>,
         #[serde(rename = "moreEnemyJungleThanOpponent")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub more_enemy_jungle_than_opponent: Option<f64>,
         /// This is an offshoot of the OneStone challenge. The code checks if a spell with the same instance ID does the final point of damage to at least 2 Champions. It doesn't matter if they're enemies, but you cannot hurt your friends.
         #[serde(rename = "multiKillOneSpell")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub multi_kill_one_spell: Option<i32>,
         #[serde(rename = "multikills")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub multikills: Option<i32>,
         #[serde(rename = "multikillsAfterAggressiveFlash")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub multikills_after_aggressive_flash: Option<i32>,
         #[serde(rename = "multiTurretRiftHeraldCount")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub multi_turret_rift_herald_count: Option<i32>,
         #[serde(rename = "outerTurretExecutesBefore10Minutes")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub outer_turret_executes_before10_minutes: Option<i32>,
         #[serde(rename = "outnumberedKills")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub outnumbered_kills: Option<i32>,
         #[serde(rename = "outnumberedNexusKill")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub outnumbered_nexus_kill: Option<i32>,
         #[serde(rename = "perfectDragonSoulsTaken")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub perfect_dragon_souls_taken: Option<i32>,
         #[serde(rename = "perfectGame")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub perfect_game: Option<i32>,
         #[serde(rename = "pickKillWithAlly")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub pick_kill_with_ally: Option<i32>,
         #[serde(rename = "poroExplosions")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub poro_explosions: Option<i32>,
         #[serde(rename = "quickCleanse")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub quick_cleanse: Option<i32>,
         #[serde(rename = "quickFirstTurret")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub quick_first_turret: Option<i32>,
         #[serde(rename = "quickSoloKills")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub quick_solo_kills: Option<i32>,
         #[serde(rename = "riftHeraldTakedowns")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub rift_herald_takedowns: Option<i32>,
         #[serde(rename = "saveAllyFromDeath")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub save_ally_from_death: Option<i32>,
         #[serde(rename = "scuttleCrabKills")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub scuttle_crab_kills: Option<i32>,
         #[serde(rename = "shortestTimeToAceFromFirstTakedown")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub shortest_time_to_ace_from_first_takedown: Option<f32>,
         #[serde(rename = "skillshotsDodged")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub skillshots_dodged: Option<i32>,
         #[serde(rename = "skillshotsHit")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub skillshots_hit: Option<i32>,
         #[serde(rename = "snowballsHit")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub snowballs_hit: Option<i32>,
         #[serde(rename = "soloBaronKills")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub solo_baron_kills: Option<i32>,
         #[serde(rename = "SWARM_DefeatAatrox")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub swarm_defeat_aatrox: Option<i32>,
         #[serde(rename = "SWARM_DefeatBriar")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub swarm_defeat_briar: Option<i32>,
         #[serde(rename = "SWARM_DefeatMiniBosses")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub swarm_defeat_mini_bosses: Option<i32>,
         #[serde(rename = "SWARM_EvolveWeapon")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub swarm_evolve_weapon: Option<i32>,
         #[serde(rename = "SWARM_Have3Passives")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub swarm_have3_passives: Option<i32>,
         #[serde(rename = "SWARM_KillEnemy")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub swarm_kill_enemy: Option<i32>,
         #[serde(rename = "SWARM_PickupGold")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub swarm_pickup_gold: Option<i32>,
         #[serde(rename = "SWARM_ReachLevel50")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub swarm_reach_level50: Option<i32>,
         #[serde(rename = "SWARM_Survive15Min")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub swarm_survive15_min: Option<i32>,
         #[serde(rename = "SWARM_WinWith5EvolvedWeapons")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub swarm_win_with5_evolved_weapons: Option<i32>,
         #[serde(rename = "soloKills")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub solo_kills: Option<i32>,
         #[serde(rename = "stealthWardsPlaced")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub stealth_wards_placed: Option<i32>,
         #[serde(rename = "survivedSingleDigitHpCount")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub survived_single_digit_hp_count: Option<i32>,
         #[serde(rename = "survivedThreeImmobilizesInFight")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub survived_three_immobilizes_in_fight: Option<i32>,
         #[serde(rename = "takedownOnFirstTurret")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub takedown_on_first_turret: Option<i32>,
         #[serde(rename = "takedowns")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub takedowns: Option<i32>,
         #[serde(rename = "takedownsAfterGainingLevelAdvantage")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub takedowns_after_gaining_level_advantage: Option<i32>,
         #[serde(rename = "takedownsBeforeJungleMinionSpawn")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub takedowns_before_jungle_minion_spawn: Option<i32>,
         #[serde(rename = "takedownsFirstXMinutes")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub takedowns_first_x_minutes: Option<i32>,
         #[serde(rename = "takedownsInAlcove")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub takedowns_in_alcove: Option<i32>,
         #[serde(rename = "takedownsInEnemyFountain")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub takedowns_in_enemy_fountain: Option<i32>,
         #[serde(rename = "teamBaronKills")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub team_baron_kills: Option<i32>,
         #[serde(rename = "teamDamagePercentage")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub team_damage_percentage: Option<f64>,
         #[serde(rename = "teamElderDragonKills")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub team_elder_dragon_kills: Option<i32>,
         #[serde(rename = "teamRiftHeraldKills")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub team_rift_herald_kills: Option<i32>,
         #[serde(rename = "tookLargeDamageSurvived")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub took_large_damage_survived: Option<i32>,
         #[serde(rename = "turretPlatesTaken")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub turret_plates_taken: Option<i32>,
         /// Any player who damages a tower that is destroyed within 30 seconds of a Rift Herald charge will receive credit. A player who does not damage the tower will not receive credit.
         #[serde(rename = "turretsTakenWithRiftHerald")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub turrets_taken_with_rift_herald: Option<i32>,
         #[serde(rename = "turretTakedowns")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub turret_takedowns: Option<i32>,
         #[serde(rename = "twentyMinionsIn3SecondsCount")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub twenty_minions_in3_seconds_count: Option<i32>,
         #[serde(rename = "twoWardsOneSweeperCount")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub two_wards_one_sweeper_count: Option<i32>,
         #[serde(rename = "unseenRecalls")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub unseen_recalls: Option<i32>,
         #[serde(rename = "visionScorePerMinute")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub vision_score_per_minute: Option<f64>,
         #[serde(rename = "wardsGuarded")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub wards_guarded: Option<i32>,
         #[serde(rename = "wardTakedowns")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub ward_takedowns: Option<i32>,
         #[serde(rename = "wardTakedownsBefore20M")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub ward_takedowns_before20_m: Option<i32>,
         #[serde(rename = "HealFromMapSources")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub heal_from_map_sources: Option<f64>,
     }
-    /// Missions data object.
+    /// `match-v5.MissionsDto` data object.
     /// # Description
     /// Missions DTO
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Missions {
         #[serde(rename = "playerScore0", alias = "PlayerScore0")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score0: Option<f32>,
         #[serde(rename = "playerScore1", alias = "PlayerScore1")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score1: Option<f32>,
         #[serde(rename = "playerScore2", alias = "PlayerScore2")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score2: Option<f32>,
         #[serde(rename = "playerScore3", alias = "PlayerScore3")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score3: Option<f32>,
         #[serde(rename = "playerScore4", alias = "PlayerScore4")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score4: Option<f32>,
         #[serde(rename = "playerScore5", alias = "PlayerScore5")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score5: Option<f32>,
         #[serde(rename = "playerScore6", alias = "PlayerScore6")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score6: Option<f32>,
         #[serde(rename = "playerScore7", alias = "PlayerScore7")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score7: Option<f32>,
         #[serde(rename = "playerScore8", alias = "PlayerScore8")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score8: Option<f32>,
         #[serde(rename = "playerScore9", alias = "PlayerScore9")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score9: Option<f32>,
         #[serde(rename = "playerScore10", alias = "PlayerScore10")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score10: Option<f32>,
         #[serde(rename = "playerScore11", alias = "PlayerScore11")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score11: Option<f32>,
     }
-    /// Perks data object.
+    /// `match-v5.PerksDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Perks {
         #[serde(rename = "statPerks")]
@@ -1911,9 +1911,9 @@ pub mod match_v5 {
         #[serde(rename = "styles")]
         pub styles: std::vec::Vec<PerkStyle>,
     }
-    /// PerkStats data object.
+    /// `match-v5.PerkStatsDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PerkStats {
         #[serde(rename = "defense")]
@@ -1923,9 +1923,9 @@ pub mod match_v5 {
         #[serde(rename = "offense")]
         pub offense: i32,
     }
-    /// PerkStyle data object.
+    /// `match-v5.PerkStyleDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PerkStyle {
         #[serde(rename = "description")]
@@ -1935,9 +1935,9 @@ pub mod match_v5 {
         #[serde(rename = "style")]
         pub style: i32,
     }
-    /// PerkStyleSelection data object.
+    /// `match-v5.PerkStyleSelectionDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PerkStyleSelection {
         #[serde(rename = "perk")]
@@ -1949,9 +1949,9 @@ pub mod match_v5 {
         #[serde(rename = "var3")]
         pub var3: i32,
     }
-    /// Team data object.
+    /// `match-v5.TeamDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Team {
         #[serde(rename = "bans")]
@@ -1963,12 +1963,12 @@ pub mod match_v5 {
         #[serde(rename = "win")]
         pub win: bool,
         #[serde(rename = "feats")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub feats: Option<Feats>,
     }
-    /// Ban data object.
+    /// `match-v5.BanDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Ban {
         #[serde(rename = "championId")]
@@ -1976,9 +1976,9 @@ pub mod match_v5 {
         #[serde(rename = "pickTurn")]
         pub pick_turn: i32,
     }
-    /// Objectives data object.
+    /// `match-v5.ObjectivesDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Objectives {
         #[serde(rename = "baron")]
@@ -1988,7 +1988,7 @@ pub mod match_v5 {
         #[serde(rename = "dragon")]
         pub dragon: Objective,
         #[serde(rename = "horde")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub horde: Option<Objective>,
         #[serde(rename = "inhibitor")]
         pub inhibitor: Objective,
@@ -1997,12 +1997,12 @@ pub mod match_v5 {
         #[serde(rename = "tower")]
         pub tower: Objective,
         #[serde(rename = "atakhan")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub atakhan: Option<Objective>,
     }
-    /// Objective data object.
+    /// `match-v5.ObjectiveDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Objective {
         #[serde(rename = "first")]
@@ -2010,9 +2010,9 @@ pub mod match_v5 {
         #[serde(rename = "kills")]
         pub kills: i32,
     }
-    /// Timeline data object.
+    /// `match-v5.TimelineDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Timeline {
         /// Match metadata.
@@ -2022,9 +2022,9 @@ pub mod match_v5 {
         #[serde(rename = "info")]
         pub info: InfoTimeLine,
     }
-    /// MetadataTimeLine data object.
+    /// `match-v5.MetadataTimeLineDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct MetadataTimeLine {
         /// Match data version.
@@ -2037,29 +2037,29 @@ pub mod match_v5 {
         #[serde(rename = "participants")]
         pub participants: std::vec::Vec<String>,
     }
-    /// InfoTimeLine data object.
+    /// `match-v5.InfoTimeLineDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct InfoTimeLine {
         /// Refer to indicate if the game ended in termination.
         #[serde(rename = "endOfGameResult")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub end_of_game_result: Option<String>,
         #[serde(rename = "frameInterval")]
         pub frame_interval: i64,
         #[serde(rename = "gameId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub game_id: Option<i64>,
         #[serde(rename = "participants")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub participants: Option<std::vec::Vec<ParticipantTimeLine>>,
         #[serde(rename = "frames")]
         pub frames: std::vec::Vec<FramesTimeLine>,
     }
-    /// ParticipantTimeLine data object.
+    /// `match-v5.ParticipantTimeLineDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ParticipantTimeLine {
         #[serde(rename = "participantId")]
@@ -2067,149 +2067,149 @@ pub mod match_v5 {
         #[serde(rename = "puuid")]
         pub puuid: String,
     }
-    /// FramesTimeLine data object.
+    /// `match-v5.FramesTimeLineDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct FramesTimeLine {
         #[serde(rename = "events")]
         pub events: std::vec::Vec<EventsTimeLine>,
         #[serde(rename = "participantFrames")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub participant_frames: Option<std::collections::HashMap<i32, ParticipantFrame>>,
         #[serde(rename = "timestamp")]
         pub timestamp: i32,
     }
-    /// EventsTimeLine data object.
+    /// `match-v5.EventsTimeLineDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct EventsTimeLine {
         #[serde(rename = "timestamp")]
         pub timestamp: i64,
         #[serde(rename = "realTimestamp")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub real_timestamp: Option<i64>,
         #[serde(rename = "type")]
         pub r#type: String,
         #[serde(rename = "itemId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub item_id: Option<i32>,
         #[serde(rename = "participantId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub participant_id: Option<i32>,
         #[serde(rename = "levelUpType")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub level_up_type: Option<String>,
         #[serde(rename = "skillSlot")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub skill_slot: Option<i32>,
         #[serde(rename = "creatorId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub creator_id: Option<i32>,
         #[serde(rename = "wardType")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub ward_type: Option<String>,
         #[serde(rename = "level")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub level: Option<i32>,
         #[serde(rename = "assistingParticipantIds")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub assisting_participant_ids: Option<std::vec::Vec<i32>>,
         #[serde(rename = "bounty")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub bounty: Option<i32>,
         #[serde(rename = "killStreakLength")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub kill_streak_length: Option<i32>,
         #[serde(rename = "killerId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub killer_id: Option<i32>,
         #[serde(rename = "position")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub position: Option<Position>,
         #[serde(rename = "victimDamageDealt")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub victim_damage_dealt: Option<std::vec::Vec<MatchTimelineVictimDamage>>,
         #[serde(rename = "victimDamageReceived")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub victim_damage_received: Option<std::vec::Vec<MatchTimelineVictimDamage>>,
         #[serde(rename = "victimId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub victim_id: Option<i32>,
         #[serde(rename = "killType")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub kill_type: Option<String>,
         #[serde(rename = "laneType")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub lane_type: Option<String>,
         #[serde(rename = "teamId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub team_id: Option<crate::consts::Team>,
         #[serde(rename = "multiKillLength")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub multi_kill_length: Option<i32>,
         #[serde(rename = "killerTeamId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub killer_team_id: Option<crate::consts::Team>,
         #[serde(rename = "monsterType")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub monster_type: Option<String>,
         #[serde(rename = "monsterSubType")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub monster_sub_type: Option<String>,
         #[serde(rename = "buildingType")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub building_type: Option<String>,
         #[serde(rename = "towerType")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub tower_type: Option<String>,
         #[serde(rename = "afterId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub after_id: Option<i32>,
         #[serde(rename = "beforeId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub before_id: Option<i32>,
         #[serde(rename = "goldGain")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub gold_gain: Option<i32>,
         #[serde(rename = "gameId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub game_id: Option<i64>,
         #[serde(rename = "winningTeam")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub winning_team: Option<i32>,
         #[serde(rename = "transformType")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub transform_type: Option<String>,
         #[serde(rename = "name")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub name: Option<String>,
         #[serde(rename = "shutdownBounty")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub shutdown_bounty: Option<i32>,
         #[serde(rename = "actualStartTime")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub actual_start_time: Option<i64>,
         #[serde(rename = "featType")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub feat_type: Option<i32>,
         #[serde(rename = "featValue")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub feat_value: Option<i32>,
     }
-    /// ParticipantFrames data object.
+    /// `match-v5.ParticipantFramesDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ParticipantFrames {
         /// Key value mapping for each participant
         #[serde(rename = "1-9")]
         pub x1_9: ParticipantFrame,
     }
-    /// ParticipantFrame data object.
+    /// `match-v5.ParticipantFrameDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ParticipantFrame {
         #[serde(rename = "championStats")]
@@ -2237,13 +2237,13 @@ pub mod match_v5 {
         #[serde(rename = "xp")]
         pub xp: i32,
     }
-    /// ChampionStats data object.
+    /// `match-v5.ChampionStatsDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ChampionStats {
         #[serde(rename = "abilityHaste")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub ability_haste: Option<i32>,
         #[serde(rename = "abilityPower")]
         pub ability_power: i32,
@@ -2282,10 +2282,10 @@ pub mod match_v5 {
         #[serde(rename = "movementSpeed")]
         pub movement_speed: i32,
         #[serde(rename = "omnivamp")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub omnivamp: Option<i32>,
         #[serde(rename = "physicalVamp")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub physical_vamp: Option<i32>,
         #[serde(rename = "power")]
         pub power: i32,
@@ -2296,9 +2296,9 @@ pub mod match_v5 {
         #[serde(rename = "spellVamp")]
         pub spell_vamp: i32,
     }
-    /// DamageStats data object.
+    /// `match-v5.DamageStatsDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct DamageStats {
         #[serde(rename = "magicDamageDone")]
@@ -2326,9 +2326,9 @@ pub mod match_v5 {
         #[serde(rename = "trueDamageTaken")]
         pub true_damage_taken: i32,
     }
-    /// Position data object.
+    /// `match-v5.PositionDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Position {
         #[serde(rename = "x")]
@@ -2336,24 +2336,24 @@ pub mod match_v5 {
         #[serde(rename = "y")]
         pub y: i32,
     }
-    /// Feats data object.
+    /// `match-v5.FeatsDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Feats {
         #[serde(rename = "EPIC_MONSTER_KILL")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub epic_monster_kill: Option<Feat>,
         #[serde(rename = "FIRST_BLOOD")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub first_blood: Option<Feat>,
         #[serde(rename = "FIRST_TURRET")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub first_turret: Option<Feat>,
     }
-    /// MatchTimelineVictimDamage data object.
+    /// `match-v5.MatchTimelineVictimDamage` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct MatchTimelineVictimDamage {
         #[serde(rename = "basic")]
@@ -2375,25 +2375,25 @@ pub mod match_v5 {
         #[serde(rename = "type")]
         pub r#type: String,
     }
-    /// Feat data object.
+    /// `match-v5.FeatDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Feat {
         #[serde(rename = "featState")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub feat_state: Option<i32>,
     }
 }
 
 /// Data structs used by [`SpectatorTftV5`](crate::endpoints::SpectatorTftV5).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod spectator_tft_v5 {
-    /// CurrentGameInfo data object.
+    /// `spectator-tft-v5.CurrentGameInfo` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct CurrentGameInfo {
         /// The ID of the game
@@ -2422,7 +2422,7 @@ pub mod spectator_tft_v5 {
         pub banned_champions: std::vec::Vec<BannedChampion>,
         /// The queue type (queue types are documented on the Game Constants page)
         #[serde(rename = "gameQueueConfigId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub game_queue_config_id: Option<crate::consts::Queue>,
         /// The observer information
         #[serde(rename = "observers")]
@@ -2431,9 +2431,9 @@ pub mod spectator_tft_v5 {
         #[serde(rename = "participants")]
         pub participants: std::vec::Vec<CurrentGameParticipant>,
     }
-    /// BannedChampion data object.
+    /// `spectator-tft-v5.BannedChampion` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct BannedChampion {
         /// The turn during which the champion was banned
@@ -2446,18 +2446,18 @@ pub mod spectator_tft_v5 {
         #[serde(rename = "teamId")]
         pub team_id: crate::consts::Team,
     }
-    /// Observer data object.
+    /// `spectator-tft-v5.Observer` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Observer {
         /// Key used to decrypt the spectator grid game data for playback
         #[serde(rename = "encryptionKey")]
         pub encryption_key: String,
     }
-    /// CurrentGameParticipant data object.
+    /// `spectator-tft-v5.CurrentGameParticipant` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct CurrentGameParticipant {
         /// The ID of the champion played by this participant
@@ -2465,7 +2465,7 @@ pub mod spectator_tft_v5 {
         pub champion_id: crate::consts::Champion,
         /// Perks/Runes Reforged Information
         #[serde(rename = "perks")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub perks: Option<Perks>,
         /// The ID of the profile icon used by this participant
         #[serde(rename = "profileIconId")]
@@ -2478,7 +2478,7 @@ pub mod spectator_tft_v5 {
         pub summoner_id: String,
         /// The encrypted puuid of this participant
         #[serde(rename = "puuid")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub puuid: Option<String>,
         /// The ID of the first summoner spell used by this participant
         #[serde(rename = "spell1Id")]
@@ -2490,12 +2490,12 @@ pub mod spectator_tft_v5 {
         #[serde(rename = "gameCustomizationObjects")]
         pub game_customization_objects: std::vec::Vec<GameCustomizationObject>,
         #[serde(rename = "riotId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub riot_id: Option<String>,
     }
-    /// Perks data object.
+    /// `spectator-tft-v5.Perks` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Perks {
         /// IDs of the perks/runes assigned.
@@ -2508,9 +2508,9 @@ pub mod spectator_tft_v5 {
         #[serde(rename = "perkSubStyle")]
         pub perk_sub_style: i64,
     }
-    /// GameCustomizationObject data object.
+    /// `spectator-tft-v5.GameCustomizationObject` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct GameCustomizationObject {
         /// Category identifier for Game Customization
@@ -2520,9 +2520,9 @@ pub mod spectator_tft_v5 {
         #[serde(rename = "content")]
         pub content: String,
     }
-    /// FeaturedGames data object.
+    /// `spectator-tft-v5.FeaturedGames` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct FeaturedGames {
         /// The list of featured games
@@ -2530,12 +2530,12 @@ pub mod spectator_tft_v5 {
         pub game_list: std::vec::Vec<FeaturedGameInfo>,
         /// The suggested interval to wait before requesting FeaturedGames again
         #[serde(rename = "clientRefreshInterval")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub client_refresh_interval: Option<i64>,
     }
-    /// FeaturedGameInfo data object.
+    /// `spectator-tft-v5.FeaturedGameInfo` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct FeaturedGameInfo {
         /// The game mode<br>
@@ -2571,9 +2571,9 @@ pub mod spectator_tft_v5 {
         #[serde(rename = "platformId")]
         pub platform_id: String,
     }
-    /// Participant data object.
+    /// `spectator-tft-v5.Participant` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Participant {
         /// The ID of the second summoner spell used by this participant
@@ -2584,11 +2584,11 @@ pub mod spectator_tft_v5 {
         pub profile_icon_id: i64,
         /// Encrypted summoner ID of this participant
         #[serde(rename = "summonerId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub summoner_id: Option<String>,
         /// Encrypted puuid of this participant
         #[serde(rename = "puuid")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub puuid: Option<String>,
         /// The ID of the champion played by this participant
         #[serde(rename = "championId")]
@@ -2600,19 +2600,19 @@ pub mod spectator_tft_v5 {
         #[serde(rename = "spell1Id")]
         pub spell1_id: i64,
         #[serde(rename = "riotId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub riot_id: Option<String>,
     }
 }
 
 /// Data structs used by [`SpectatorV5`](crate::endpoints::SpectatorV5).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod spectator_v5 {
-    /// CurrentGameInfo data object.
+    /// `spectator-v5.CurrentGameInfo` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct CurrentGameInfo {
         /// The ID of the game
@@ -2641,7 +2641,7 @@ pub mod spectator_v5 {
         pub banned_champions: std::vec::Vec<BannedChampion>,
         /// The queue type (queue types are documented on the Game Constants page)
         #[serde(rename = "gameQueueConfigId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub game_queue_config_id: Option<crate::consts::Queue>,
         /// The observer information
         #[serde(rename = "observers")]
@@ -2650,9 +2650,9 @@ pub mod spectator_v5 {
         #[serde(rename = "participants")]
         pub participants: std::vec::Vec<CurrentGameParticipant>,
     }
-    /// BannedChampion data object.
+    /// `spectator-v5.BannedChampion` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct BannedChampion {
         /// The turn during which the champion was banned
@@ -2665,18 +2665,18 @@ pub mod spectator_v5 {
         #[serde(rename = "teamId")]
         pub team_id: crate::consts::Team,
     }
-    /// Observer data object.
+    /// `spectator-v5.Observer` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Observer {
         /// Key used to decrypt the spectator grid game data for playback
         #[serde(rename = "encryptionKey")]
         pub encryption_key: String,
     }
-    /// CurrentGameParticipant data object.
+    /// `spectator-v5.CurrentGameParticipant` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct CurrentGameParticipant {
         /// The ID of the champion played by this participant
@@ -2684,7 +2684,7 @@ pub mod spectator_v5 {
         pub champion_id: crate::consts::Champion,
         /// Perks/Runes Reforged Information
         #[serde(rename = "perks")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub perks: Option<Perks>,
         /// The ID of the profile icon used by this participant
         #[serde(rename = "profileIconId")]
@@ -2700,7 +2700,7 @@ pub mod spectator_v5 {
         pub summoner_id: String,
         /// The encrypted puuid of this participant
         #[serde(rename = "puuid")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub puuid: Option<String>,
         /// The ID of the first summoner spell used by this participant
         #[serde(rename = "spell1Id")]
@@ -2712,12 +2712,12 @@ pub mod spectator_v5 {
         #[serde(rename = "gameCustomizationObjects")]
         pub game_customization_objects: std::vec::Vec<GameCustomizationObject>,
         #[serde(rename = "riotId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub riot_id: Option<String>,
     }
-    /// Perks data object.
+    /// `spectator-v5.Perks` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Perks {
         /// IDs of the perks/runes assigned.
@@ -2730,9 +2730,9 @@ pub mod spectator_v5 {
         #[serde(rename = "perkSubStyle")]
         pub perk_sub_style: i64,
     }
-    /// GameCustomizationObject data object.
+    /// `spectator-v5.GameCustomizationObject` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct GameCustomizationObject {
         /// Category identifier for Game Customization
@@ -2742,9 +2742,9 @@ pub mod spectator_v5 {
         #[serde(rename = "content")]
         pub content: String,
     }
-    /// FeaturedGames data object.
+    /// `spectator-v5.FeaturedGames` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct FeaturedGames {
         /// The list of featured games
@@ -2752,12 +2752,12 @@ pub mod spectator_v5 {
         pub game_list: std::vec::Vec<FeaturedGameInfo>,
         /// The suggested interval to wait before requesting FeaturedGames again
         #[serde(rename = "clientRefreshInterval")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub client_refresh_interval: Option<i64>,
     }
-    /// FeaturedGameInfo data object.
+    /// `spectator-v5.FeaturedGameInfo` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct FeaturedGameInfo {
         /// The game mode<br>
@@ -2793,9 +2793,9 @@ pub mod spectator_v5 {
         #[serde(rename = "platformId")]
         pub platform_id: String,
     }
-    /// Participant data object.
+    /// `spectator-v5.Participant` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Participant {
         /// Flag indicating whether or not this participant is a bot
@@ -2809,11 +2809,11 @@ pub mod spectator_v5 {
         pub profile_icon_id: i64,
         /// Encrypted summoner ID of this participant
         #[serde(rename = "summonerId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub summoner_id: Option<String>,
         /// Encrypted puuid of this participant
         #[serde(rename = "puuid")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub puuid: Option<String>,
         /// The ID of the champion played by this participant
         #[serde(rename = "championId")]
@@ -2825,23 +2825,23 @@ pub mod spectator_v5 {
         #[serde(rename = "spell1Id")]
         pub spell1_id: i64,
         #[serde(rename = "riotId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub riot_id: Option<String>,
     }
 }
 
 /// Data structs used by [`SummonerV4`](crate::endpoints::SummonerV4).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod summoner_v4 {
-    /// Summoner data object.
+    /// `summoner-v4.SummonerDTO` data object.
     /// # Description
     /// represents a summoner
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Summoner {
         /// Encrypted account ID. Max length 56 characters.
@@ -2866,32 +2866,32 @@ pub mod summoner_v4 {
 }
 
 /// Data structs used by [`TftLeagueV1`](crate::endpoints::TftLeagueV1).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod tft_league_v1 {
-    /// LeagueList data object.
+    /// `tft-league-v1.LeagueListDTO` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LeagueList {
         #[serde(rename = "leagueId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub league_id: Option<String>,
         #[serde(rename = "entries")]
         pub entries: std::vec::Vec<LeagueItem>,
         #[serde(rename = "tier")]
         pub tier: crate::consts::Tier,
         #[serde(rename = "name")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub name: Option<String>,
         #[serde(rename = "queue")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub queue: Option<crate::consts::QueueType>,
     }
-    /// LeagueItem data object.
+    /// `tft-league-v1.LeagueItemDTO` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LeagueItem {
         #[serde(rename = "freshBlood")]
@@ -2900,7 +2900,7 @@ pub mod tft_league_v1 {
         #[serde(rename = "wins")]
         pub wins: i32,
         #[serde(rename = "miniSeries")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub mini_series: Option<MiniSeries>,
         #[serde(rename = "inactive")]
         pub inactive: bool,
@@ -2922,9 +2922,9 @@ pub mod tft_league_v1 {
         #[serde(rename = "puuid")]
         pub puuid: String,
     }
-    /// MiniSeries data object.
+    /// `tft-league-v1.MiniSeriesDTO` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct MiniSeries {
         #[serde(rename = "losses")]
@@ -2936,18 +2936,18 @@ pub mod tft_league_v1 {
         #[serde(rename = "wins")]
         pub wins: i32,
     }
-    /// LeagueEntry data object.
+    /// `tft-league-v1.LeagueEntryDTO` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LeagueEntry {
         /// Player Universal Unique Identifier. Exact length of 78 characters. (Encrypted)
         #[serde(rename = "puuid")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub puuid: Option<String>,
         /// Not included for the RANKED_TFT_TURBO queueType.
         #[serde(rename = "leagueId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub league_id: Option<String>,
         /// Player's encrypted summonerId.
         #[serde(rename = "summonerId")]
@@ -2957,23 +2957,23 @@ pub mod tft_league_v1 {
         /// Only included for the RANKED_TFT_TURBO queueType.<br>
         /// (Legal values:  ORANGE,  PURPLE,  BLUE,  GREEN,  GRAY)
         #[serde(rename = "ratedTier")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub rated_tier: Option<String>,
         /// Only included for the RANKED_TFT_TURBO queueType.
         #[serde(rename = "ratedRating")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub rated_rating: Option<i32>,
         /// Not included for the RANKED_TFT_TURBO queueType.
         #[serde(rename = "tier")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub tier: Option<crate::consts::Tier>,
         /// The player's division within a tier. Not included for the RANKED_TFT_TURBO queueType.
         #[serde(rename = "rank")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub rank: Option<crate::consts::Division>,
         /// Not included for the RANKED_TFT_TURBO queueType.
         #[serde(rename = "leaguePoints")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub league_points: Option<i32>,
         /// First placement.
         #[serde(rename = "wins")]
@@ -2983,28 +2983,28 @@ pub mod tft_league_v1 {
         pub losses: i32,
         /// Not included for the RANKED_TFT_TURBO queueType.
         #[serde(rename = "hotStreak")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub hot_streak: Option<bool>,
         /// Not included for the RANKED_TFT_TURBO queueType.
         #[serde(rename = "veteran")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub veteran: Option<bool>,
         /// Not included for the RANKED_TFT_TURBO queueType.
         #[serde(rename = "freshBlood")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub fresh_blood: Option<bool>,
         /// Not included for the RANKED_TFT_TURBO queueType.
         #[serde(rename = "inactive")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub inactive: Option<bool>,
         /// Not included for the RANKED_TFT_TURBO queueType.
         #[serde(rename = "miniSeries")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub mini_series: Option<MiniSeries>,
     }
-    /// TopRatedLadderEntry data object.
+    /// `tft-league-v1.TopRatedLadderEntryDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TopRatedLadderEntry {
         #[serde(rename = "summonerId")]
@@ -3023,13 +3023,13 @@ pub mod tft_league_v1 {
 }
 
 /// Data structs used by [`TftMatchV1`](crate::endpoints::TftMatchV1).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod tft_match_v1 {
-    /// Match data object.
+    /// `tft-match-v1.MatchDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Match {
         /// Match metadata.
@@ -3039,9 +3039,9 @@ pub mod tft_match_v1 {
         #[serde(rename = "info")]
         pub info: Info,
     }
-    /// Metadata data object.
+    /// `tft-match-v1.MetadataDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Metadata {
         /// Match data version.
@@ -3054,9 +3054,9 @@ pub mod tft_match_v1 {
         #[serde(rename = "participants")]
         pub participants: std::vec::Vec<String>,
     }
-    /// Info data object.
+    /// `tft-match-v1.InfoDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Info {
         /// Unix timestamp.
@@ -3067,7 +3067,7 @@ pub mod tft_match_v1 {
         pub game_length: f32,
         /// Game variation key. Game variations documented in TFT static data.
         #[serde(rename = "game_variation")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub game_variation: Option<String>,
         /// Game client version.
         #[serde(rename = "game_version")]
@@ -3081,31 +3081,31 @@ pub mod tft_match_v1 {
         #[serde(rename = "tft_set_number")]
         pub tft_set_number: i32,
         #[serde(rename = "tft_game_type")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub tft_game_type: Option<String>,
         #[serde(rename = "tft_set_core_name")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub tft_set_core_name: Option<String>,
         #[serde(rename = "endOfGameResult")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub end_of_game_result: Option<String>,
         #[serde(rename = "gameCreation")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub game_creation: Option<i64>,
         #[serde(rename = "gameId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub game_id: Option<i64>,
         #[serde(rename = "mapId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub map_id: Option<i64>,
         /// Please refer to the League of Legends documentation.
         #[serde(rename = "queueId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub queue_id_: Option<crate::consts::Queue>,
     }
-    /// Participant data object.
+    /// `tft-match-v1.ParticipantDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Participant {
         /// Participant's companion.
@@ -3129,10 +3129,10 @@ pub mod tft_match_v1 {
         #[serde(rename = "puuid")]
         pub puuid: String,
         #[serde(rename = "riotIdGameName")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub riot_id_game_name: Option<String>,
         #[serde(rename = "riotIdTagline")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub riot_id_tagline: Option<String>,
         /// The number of seconds before the participant was eliminated.
         #[serde(rename = "time_eliminated")]
@@ -3147,24 +3147,24 @@ pub mod tft_match_v1 {
         #[serde(rename = "units")]
         pub units: std::vec::Vec<Unit>,
         #[serde(rename = "augments")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub augments: Option<std::vec::Vec<String>>,
         #[serde(rename = "partner_group_id")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub partner_group_id: Option<i32>,
         #[serde(rename = "missions")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub missions: Option<ParticipantMissions>,
         #[serde(rename = "win")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub win: Option<bool>,
         #[serde(rename = "skill_tree")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub skill_tree: Option<std::collections::HashMap<String, i32>>,
     }
-    /// Trait data object.
+    /// `tft-match-v1.TraitDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Trait {
         /// Trait name.
@@ -3175,31 +3175,31 @@ pub mod tft_match_v1 {
         pub num_units: i32,
         /// Current style for this trait. (0 = No style, 1 = Bronze, 2 = Silver, 3 = Gold, 4 = Chromatic)
         #[serde(rename = "style")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub style: Option<i32>,
         /// Current active tier for the trait.
         #[serde(rename = "tier_current")]
         pub tier_current: i32,
         /// Total tiers for the trait.
         #[serde(rename = "tier_total")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub tier_total: Option<i32>,
     }
-    /// Unit data object.
+    /// `tft-match-v1.UnitDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Unit {
         /// A list of the unit's items. Please refer to the Teamfight Tactics documentation for item ids.
         #[serde(rename = "items")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub items: Option<std::vec::Vec<i32>>,
         /// This field was introduced in patch 9.22 with data_version 2.
         #[serde(rename = "character_id")]
         pub character_id: String,
         /// If a unit is chosen as part of the Fates set mechanic, the chosen trait will be indicated by this field. Otherwise this field is excluded from the response.
         #[serde(rename = "chosen")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub chosen: Option<String>,
         /// Unit name. This field is often left blank.
         #[serde(rename = "name")]
@@ -3211,16 +3211,16 @@ pub mod tft_match_v1 {
         #[serde(rename = "tier")]
         pub tier: i32,
         #[serde(rename = "itemNames")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub item_names: Option<std::vec::Vec<String>>,
     }
-    /// Companion data object.
+    /// `tft-match-v1.CompanionDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Companion {
         #[serde(rename = "item_ID")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub item_id: Option<i32>,
         #[serde(rename = "skin_ID")]
         pub skin_id: i32,
@@ -3229,166 +3229,166 @@ pub mod tft_match_v1 {
         #[serde(rename = "species")]
         pub species: String,
     }
-    /// ParticipantMissions data object.
+    /// `tft-match-v1.ParticipantMissionsDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ParticipantMissions {
         #[serde(rename = "Assists")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub assists: Option<i32>,
         #[serde(rename = "DamageDealt")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub damage_dealt: Option<i32>,
         #[serde(rename = "DamageDealtToObjectives")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub damage_dealt_to_objectives: Option<i32>,
         #[serde(rename = "DamageDealtToTurrets")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub damage_dealt_to_turrets: Option<i32>,
         #[serde(rename = "DamageTaken")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub damage_taken: Option<i32>,
         #[serde(rename = "DoubleKills")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub double_kills: Option<i32>,
         #[serde(rename = "GoldEarned")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub gold_earned: Option<i32>,
         #[serde(rename = "GoldSpent")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub gold_spent: Option<i32>,
         #[serde(rename = "InhibitorsDestroyed")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub inhibitors_destroyed: Option<i32>,
         #[serde(rename = "Kills")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub kills: Option<i32>,
         #[serde(rename = "LargestKillingSpree")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub largest_killing_spree: Option<i32>,
         #[serde(rename = "LargestMultiKill")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub largest_multi_kill: Option<i32>,
         #[serde(rename = "MagicDamageDealt")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub magic_damage_dealt: Option<i32>,
         #[serde(rename = "MagicDamageDealtToChampions")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub magic_damage_dealt_to_champions: Option<i32>,
         #[serde(rename = "NeutralMinionsKilledTeamJungle")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub neutral_minions_killed_team_jungle: Option<i32>,
         #[serde(rename = "PhysicalDamageDealt")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub physical_damage_dealt: Option<i32>,
         #[serde(rename = "PhysicalDamageTaken")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub physical_damage_taken: Option<i32>,
         #[serde(rename = "PlayerScore0")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score0: Option<i32>,
         #[serde(rename = "PlayerScore1")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score1: Option<i32>,
         #[serde(rename = "PlayerScore2")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score2: Option<i32>,
         #[serde(rename = "PlayerScore3")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score3: Option<i32>,
         #[serde(rename = "PlayerScore4")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score4: Option<i32>,
         #[serde(rename = "PlayerScore5")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score5: Option<i32>,
         #[serde(rename = "PlayerScore6")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score6: Option<i32>,
         #[serde(rename = "PlayerScore9")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score9: Option<i32>,
         #[serde(rename = "PlayerScore10")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score10: Option<i32>,
         #[serde(rename = "PlayerScore11")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub player_score11: Option<i32>,
         #[serde(rename = "QuadraKills")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub quadra_kills: Option<i32>,
         #[serde(rename = "Spell1Casts")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub spell1_casts: Option<i32>,
         #[serde(rename = "Spell2Casts")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub spell2_casts: Option<i32>,
         #[serde(rename = "Spell3Casts")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub spell3_casts: Option<i32>,
         #[serde(rename = "Spell4Casts")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub spell4_casts: Option<i32>,
         #[serde(rename = "SummonerSpell1Casts")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub summoner_spell1_casts: Option<i32>,
         #[serde(rename = "TimeCCOthers")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub time_cc_others: Option<i32>,
         #[serde(rename = "TotalMinionsKilled")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub total_minions_killed: Option<i32>,
         #[serde(rename = "TrueDamageDealtToChampions")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub true_damage_dealt_to_champions: Option<i32>,
         #[serde(rename = "UnrealKills")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub unreal_kills: Option<i32>,
         #[serde(rename = "VisionScore")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub vision_score: Option<i32>,
         #[serde(rename = "WardsKilled")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub wards_killed: Option<i32>,
         #[serde(rename = "Deaths")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub deaths: Option<i32>,
         #[serde(rename = "KillingSprees")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub killing_sprees: Option<i32>,
         #[serde(rename = "MagicDamageTaken")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub magic_damage_taken: Option<i32>,
         #[serde(rename = "PentaKills")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub penta_kills: Option<i32>,
         #[serde(rename = "PhysicalDamageDealtToChampions")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub physical_damage_dealt_to_champions: Option<i32>,
         #[serde(rename = "TotalDamageDealtToChampions")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub total_damage_dealt_to_champions: Option<i32>,
         #[serde(rename = "TripleKills")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub triple_kills: Option<i32>,
         #[serde(rename = "TrueDamageDealt")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub true_damage_dealt: Option<i32>,
         #[serde(rename = "TrueDamageTaken")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub true_damage_taken: Option<i32>,
     }
 }
 
 /// Data structs used by [`TftStatusV1`](crate::endpoints::TftStatusV1).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod tft_status_v1 {
-    /// PlatformData data object.
+    /// `tft-status-v1.PlatformDataDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlatformData {
         #[serde(rename = "id")]
@@ -3402,9 +3402,9 @@ pub mod tft_status_v1 {
         #[serde(rename = "incidents")]
         pub incidents: std::vec::Vec<Status>,
     }
-    /// Status data object.
+    /// `tft-status-v1.StatusDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Status {
         #[serde(rename = "id")]
@@ -3429,9 +3429,9 @@ pub mod tft_status_v1 {
         #[serde(rename = "platforms")]
         pub platforms: std::vec::Vec<String>,
     }
-    /// Content data object.
+    /// `tft-status-v1.ContentDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Content {
         #[serde(rename = "locale")]
@@ -3439,9 +3439,9 @@ pub mod tft_status_v1 {
         #[serde(rename = "content")]
         pub content: String,
     }
-    /// Update data object.
+    /// `tft-status-v1.UpdateDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Update {
         #[serde(rename = "id")]
@@ -3463,17 +3463,17 @@ pub mod tft_status_v1 {
 }
 
 /// Data structs used by [`TftSummonerV1`](crate::endpoints::TftSummonerV1).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod tft_summoner_v1 {
-    /// Summoner data object.
+    /// `tft-summoner-v1.SummonerDTO` data object.
     /// # Description
     /// represents a summoner
     ///
     /// Note: This struct is automatically generated
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Summoner {
         /// Encrypted account ID. Max length 56 characters.
@@ -3498,22 +3498,22 @@ pub mod tft_summoner_v1 {
 }
 
 /// Data structs used by [`TournamentStubV5`](crate::endpoints::TournamentStubV5).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod tournament_stub_v5 {
-    /// TournamentCodeParametersV5 data object.
+    /// `tournament-stub-v5.TournamentCodeParametersV5` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TournamentCodeParametersV5 {
         /// Optional list of encrypted puuids in order to validate the players eligible to join the lobby. NOTE: We currently do not enforce participants at the team level, but rather the aggregate of teamOne and teamTwo. We may add the ability to enforce at the team level in the future.
         #[serde(rename = "allowedParticipants")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub allowed_participants: Option<std::vec::Vec<String>>,
         /// Optional string that may contain any data in any format, if specified at all. Used to denote any custom information about the game.
         #[serde(rename = "metadata")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub metadata: Option<String>,
         /// The team size of the game. Valid values are 1-5.
         #[serde(rename = "teamSize")]
@@ -3534,9 +3534,9 @@ pub mod tournament_stub_v5 {
         #[serde(rename = "enoughPlayers")]
         pub enough_players: bool,
     }
-    /// TournamentCodeV5 data object.
+    /// `tournament-stub-v5.TournamentCodeV5DTO` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TournamentCodeV5 {
         /// The tournament code.
@@ -3580,17 +3580,17 @@ pub mod tournament_stub_v5 {
         #[serde(rename = "participants")]
         pub participants: std::vec::Vec<String>,
     }
-    /// LobbyEventV5Wrapper data object.
+    /// `tournament-stub-v5.LobbyEventV5DTOWrapper` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LobbyEventV5Wrapper {
         #[serde(rename = "eventList")]
         pub event_list: std::vec::Vec<LobbyEventV5>,
     }
-    /// LobbyEventV5 data object.
+    /// `tournament-stub-v5.LobbyEventV5DTO` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LobbyEventV5 {
         /// Timestamp from the event
@@ -3603,9 +3603,9 @@ pub mod tournament_stub_v5 {
         #[serde(rename = "puuid")]
         pub puuid: String,
     }
-    /// ProviderRegistrationParametersV5 data object.
+    /// `tournament-stub-v5.ProviderRegistrationParametersV5` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ProviderRegistrationParametersV5 {
         /// The region in which the provider will be running tournaments.<br>
@@ -3616,9 +3616,9 @@ pub mod tournament_stub_v5 {
         #[serde(rename = "url")]
         pub url: String,
     }
-    /// TournamentRegistrationParametersV5 data object.
+    /// `tournament-stub-v5.TournamentRegistrationParametersV5` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TournamentRegistrationParametersV5 {
         /// The provider ID to specify the regional registered provider data to associate this tournament.
@@ -3626,28 +3626,28 @@ pub mod tournament_stub_v5 {
         pub provider_id: i32,
         /// The optional name of the tournament.
         #[serde(rename = "name")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub name: Option<String>,
     }
 }
 
 /// Data structs used by [`TournamentV5`](crate::endpoints::TournamentV5).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod tournament_v5 {
-    /// TournamentCodeParametersV5 data object.
+    /// `tournament-v5.TournamentCodeParametersV5` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TournamentCodeParametersV5 {
         /// Optional list of encrypted puuids in order to validate the players eligible to join the lobby. NOTE: We currently do not enforce participants at the team level, but rather the aggregate of teamOne and teamTwo. We may add the ability to enforce at the team level in the future.
         #[serde(rename = "allowedParticipants")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub allowed_participants: Option<std::vec::Vec<String>>,
         /// Optional string that may contain any data in any format, if specified at all. Used to denote any custom information about the game.
         #[serde(rename = "metadata")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub metadata: Option<String>,
         /// The team size of the game. Valid values are 1-5.
         #[serde(rename = "teamSize")]
@@ -3668,9 +3668,9 @@ pub mod tournament_v5 {
         #[serde(rename = "enoughPlayers")]
         pub enough_players: bool,
     }
-    /// TournamentCodeV5 data object.
+    /// `tournament-v5.TournamentCodeV5DTO` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TournamentCodeV5 {
         /// The tournament code.
@@ -3714,14 +3714,14 @@ pub mod tournament_v5 {
         #[serde(rename = "participants")]
         pub participants: std::vec::Vec<String>,
     }
-    /// TournamentCodeUpdateParametersV5 data object.
+    /// `tournament-v5.TournamentCodeUpdateParametersV5` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TournamentCodeUpdateParametersV5 {
         /// Optional list of encrypted puuids in order to validate the players eligible to join the lobby. NOTE: We currently do not enforce participants at the team level, but rather the aggregate of teamOne and teamTwo. We may add the ability to enforce at the team level in the future.
         #[serde(rename = "allowedParticipants")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub allowed_participants: Option<std::vec::Vec<String>>,
         /// The pick type<br>
         /// (Legal values:  BLIND_PICK,  DRAFT_MODE,  ALL_RANDOM,  TOURNAMENT_DRAFT)
@@ -3736,9 +3736,9 @@ pub mod tournament_v5 {
         #[serde(rename = "spectatorType")]
         pub spectator_type: String,
     }
-    /// TournamentGamesV5 data object.
+    /// `tournament-v5.TournamentGamesV5` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TournamentGamesV5 {
         #[serde(rename = "winningTeam")]
@@ -3750,7 +3750,7 @@ pub mod tournament_v5 {
         pub short_code: String,
         /// Metadata for the TournamentCode
         #[serde(rename = "metaData")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub meta_data: Option<String>,
         #[serde(rename = "gameId")]
         pub game_id: i64,
@@ -3767,26 +3767,26 @@ pub mod tournament_v5 {
         #[serde(rename = "region")]
         pub region: String,
     }
-    /// TournamentTeamV5 data object.
+    /// `tournament-v5.TournamentTeamV5` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TournamentTeamV5 {
         /// Player Unique UUID (Encrypted)
         #[serde(rename = "puuid")]
         pub puuid: String,
     }
-    /// LobbyEventV5Wrapper data object.
+    /// `tournament-v5.LobbyEventV5DTOWrapper` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LobbyEventV5Wrapper {
         #[serde(rename = "eventList")]
         pub event_list: std::vec::Vec<LobbyEventV5>,
     }
-    /// LobbyEventV5 data object.
+    /// `tournament-v5.LobbyEventV5DTO` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LobbyEventV5 {
         /// Timestamp from the event
@@ -3799,9 +3799,9 @@ pub mod tournament_v5 {
         #[serde(rename = "puuid")]
         pub puuid: String,
     }
-    /// ProviderRegistrationParametersV5 data object.
+    /// `tournament-v5.ProviderRegistrationParametersV5` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ProviderRegistrationParametersV5 {
         /// The region in which the provider will be running tournaments.<br>
@@ -3812,9 +3812,9 @@ pub mod tournament_v5 {
         #[serde(rename = "url")]
         pub url: String,
     }
-    /// TournamentRegistrationParametersV5 data object.
+    /// `tournament-v5.TournamentRegistrationParametersV5` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TournamentRegistrationParametersV5 {
         /// The provider ID to specify the regional registered provider data to associate this tournament.
@@ -3822,19 +3822,19 @@ pub mod tournament_v5 {
         pub provider_id: i32,
         /// The optional name of the tournament.
         #[serde(rename = "name")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub name: Option<String>,
     }
 }
 
 /// Data structs used by [`ValConsoleMatchV1`](crate::endpoints::ValConsoleMatchV1).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod val_console_match_v1 {
-    /// Match data object.
+    /// `val-console-match-v1.MatchDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Match {
         #[serde(rename = "matchInfo")]
@@ -3848,9 +3848,9 @@ pub mod val_console_match_v1 {
         #[serde(rename = "roundResults")]
         pub round_results: std::vec::Vec<RoundResult>,
     }
-    /// MatchInfo data object.
+    /// `val-console-match-v1.MatchInfoDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct MatchInfo {
         #[serde(rename = "matchId")]
@@ -3876,9 +3876,9 @@ pub mod val_console_match_v1 {
         #[serde(rename = "seasonId")]
         pub season_id: String,
     }
-    /// Player data object.
+    /// `val-console-match-v1.PlayerDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Player {
         #[serde(rename = "puuid")]
@@ -3902,9 +3902,9 @@ pub mod val_console_match_v1 {
         #[serde(rename = "playerTitle")]
         pub player_title: String,
     }
-    /// PlayerStats data object.
+    /// `val-console-match-v1.PlayerStatsDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlayerStats {
         #[serde(rename = "score")]
@@ -3922,9 +3922,9 @@ pub mod val_console_match_v1 {
         #[serde(rename = "abilityCasts")]
         pub ability_casts: AbilityCasts,
     }
-    /// AbilityCasts data object.
+    /// `val-console-match-v1.AbilityCastsDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct AbilityCasts {
         #[serde(rename = "grenadeCasts")]
@@ -3936,9 +3936,9 @@ pub mod val_console_match_v1 {
         #[serde(rename = "ultimateCasts")]
         pub ultimate_casts: i32,
     }
-    /// Coach data object.
+    /// `val-console-match-v1.CoachDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Coach {
         #[serde(rename = "puuid")]
@@ -3946,9 +3946,9 @@ pub mod val_console_match_v1 {
         #[serde(rename = "teamId")]
         pub team_id: String,
     }
-    /// Team data object.
+    /// `val-console-match-v1.TeamDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Team {
         /// This is an arbitrary string. Red and Blue in bomb modes. The puuid of the player in deathmatch.
@@ -3964,9 +3964,9 @@ pub mod val_console_match_v1 {
         #[serde(rename = "numPoints")]
         pub num_points: i32,
     }
-    /// RoundResult data object.
+    /// `val-console-match-v1.RoundResultDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct RoundResult {
         #[serde(rename = "roundNum")]
@@ -4002,9 +4002,9 @@ pub mod val_console_match_v1 {
         #[serde(rename = "roundResultCode")]
         pub round_result_code: String,
     }
-    /// PlayerLocations data object.
+    /// `val-console-match-v1.PlayerLocationsDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlayerLocations {
         #[serde(rename = "puuid")]
@@ -4014,9 +4014,9 @@ pub mod val_console_match_v1 {
         #[serde(rename = "location")]
         pub location: Location,
     }
-    /// Location data object.
+    /// `val-console-match-v1.LocationDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Location {
         #[serde(rename = "x")]
@@ -4024,9 +4024,9 @@ pub mod val_console_match_v1 {
         #[serde(rename = "y")]
         pub y: i32,
     }
-    /// PlayerRoundStats data object.
+    /// `val-console-match-v1.PlayerRoundStatsDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlayerRoundStats {
         #[serde(rename = "puuid")]
@@ -4042,9 +4042,9 @@ pub mod val_console_match_v1 {
         #[serde(rename = "ability")]
         pub ability: Ability,
     }
-    /// Kill data object.
+    /// `val-console-match-v1.KillDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Kill {
         #[serde(rename = "timeSinceGameStartMillis")]
@@ -4067,9 +4067,9 @@ pub mod val_console_match_v1 {
         #[serde(rename = "finishingDamage")]
         pub finishing_damage: FinishingDamage,
     }
-    /// FinishingDamage data object.
+    /// `val-console-match-v1.FinishingDamageDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct FinishingDamage {
         #[serde(rename = "damageType")]
@@ -4079,9 +4079,9 @@ pub mod val_console_match_v1 {
         #[serde(rename = "isSecondaryFireMode")]
         pub is_secondary_fire_mode: bool,
     }
-    /// Damage data object.
+    /// `val-console-match-v1.DamageDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Damage {
         /// PUUID
@@ -4096,9 +4096,9 @@ pub mod val_console_match_v1 {
         #[serde(rename = "headshots")]
         pub headshots: i32,
     }
-    /// Economy data object.
+    /// `val-console-match-v1.EconomyDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Economy {
         #[serde(rename = "loadoutValue")]
@@ -4112,9 +4112,9 @@ pub mod val_console_match_v1 {
         #[serde(rename = "spent")]
         pub spent: i32,
     }
-    /// Ability data object.
+    /// `val-console-match-v1.AbilityDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Ability {
         #[serde(rename = "grenadeEffects")]
@@ -4126,9 +4126,9 @@ pub mod val_console_match_v1 {
         #[serde(rename = "ultimateEffects")]
         pub ultimate_effects: String,
     }
-    /// Matchlist data object.
+    /// `val-console-match-v1.MatchlistDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Matchlist {
         #[serde(rename = "puuid")]
@@ -4136,9 +4136,9 @@ pub mod val_console_match_v1 {
         #[serde(rename = "history")]
         pub history: std::vec::Vec<MatchlistEntry>,
     }
-    /// MatchlistEntry data object.
+    /// `val-console-match-v1.MatchlistEntryDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct MatchlistEntry {
         #[serde(rename = "matchId")]
@@ -4148,9 +4148,9 @@ pub mod val_console_match_v1 {
         #[serde(rename = "queueId")]
         pub queue_id: String,
     }
-    /// RecentMatches data object.
+    /// `val-console-match-v1.RecentMatchesDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct RecentMatches {
         #[serde(rename = "currentTime")]
@@ -4162,13 +4162,13 @@ pub mod val_console_match_v1 {
 }
 
 /// Data structs used by [`ValConsoleRankedV1`](crate::endpoints::ValConsoleRankedV1).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod val_console_ranked_v1 {
-    /// Leaderboard data object.
+    /// `val-console-ranked-v1.LeaderboardDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Leaderboard {
         /// The shard for the given leaderboard.
@@ -4183,9 +4183,9 @@ pub mod val_console_ranked_v1 {
         #[serde(rename = "players")]
         pub players: std::vec::Vec<Player>,
     }
-    /// Player data object.
+    /// `val-console-ranked-v1.PlayerDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Player {
         /// This field may be omitted if the player has been anonymized.
@@ -4207,13 +4207,13 @@ pub mod val_console_ranked_v1 {
 }
 
 /// Data structs used by [`ValContentV1`](crate::endpoints::ValContentV1).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod val_content_v1 {
-    /// Content data object.
+    /// `val-content-v1.ContentDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Content {
         #[serde(rename = "version")]
@@ -4247,22 +4247,22 @@ pub mod val_content_v1 {
         #[serde(rename = "acts")]
         pub acts: std::vec::Vec<Act>,
         #[serde(rename = "ceremonies")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub ceremonies: Option<std::vec::Vec<ContentItem>>,
         #[serde(rename = "totems")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub totems: Option<std::vec::Vec<ContentItem>>,
     }
-    /// ContentItem data object.
+    /// `val-content-v1.ContentItemDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct ContentItem {
         #[serde(rename = "name")]
         pub name: String,
         /// This field is excluded from the response when a locale is set
         #[serde(rename = "localizedNames")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub localized_names: Option<LocalizedNames>,
         #[serde(rename = "id")]
         pub id: String,
@@ -4270,12 +4270,12 @@ pub mod val_content_v1 {
         pub asset_name: String,
         /// This field is only included for maps and game modes. These values are used in the match response.
         #[serde(rename = "assetPath")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub asset_path: Option<String>,
     }
-    /// LocalizedNames data object.
+    /// `val-content-v1.LocalizedNamesDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct LocalizedNames {
         #[serde(rename = "ar-AE")]
@@ -4283,7 +4283,7 @@ pub mod val_content_v1 {
         #[serde(rename = "de-DE")]
         pub de_de: String,
         #[serde(rename = "en-GB")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub en_gb: Option<String>,
         #[serde(rename = "en-US")]
         pub en_us: String,
@@ -4318,38 +4318,38 @@ pub mod val_content_v1 {
         #[serde(rename = "zh-TW")]
         pub zh_tw: String,
     }
-    /// Act data object.
+    /// `val-content-v1.ActDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Act {
         #[serde(rename = "name")]
         pub name: String,
         /// This field is excluded from the response when a locale is set
         #[serde(rename = "localizedNames")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub localized_names: Option<LocalizedNames>,
         #[serde(rename = "id")]
         pub id: String,
         #[serde(rename = "isActive")]
         pub is_active: bool,
         #[serde(rename = "parentId")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub parent_id: Option<String>,
         #[serde(rename = "type")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub r#type: Option<String>,
     }
 }
 
 /// Data structs used by [`ValMatchV1`](crate::endpoints::ValMatchV1).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod val_match_v1 {
-    /// Match data object.
+    /// `val-match-v1.MatchDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Match {
         #[serde(rename = "matchInfo")]
@@ -4359,15 +4359,15 @@ pub mod val_match_v1 {
         #[serde(rename = "coaches")]
         pub coaches: std::vec::Vec<Coach>,
         #[serde(rename = "teams")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub teams: Option<std::vec::Vec<Team>>,
         #[serde(rename = "roundResults")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub round_results: Option<std::vec::Vec<RoundResult>>,
     }
-    /// MatchInfo data object.
+    /// `val-match-v1.MatchInfoDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct MatchInfo {
         #[serde(rename = "matchId")]
@@ -4375,7 +4375,7 @@ pub mod val_match_v1 {
         #[serde(rename = "mapId")]
         pub map_id: String,
         #[serde(rename = "gameLengthMillis")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub game_length_millis: Option<i32>,
         #[serde(rename = "gameStartMillis")]
         pub game_start_millis: i64,
@@ -4398,12 +4398,11 @@ pub mod val_match_v1 {
         #[serde(rename = "region")]
         pub region: String,
         #[serde(rename = "premierMatchInfo")]
-        #[eserde(compat)]
         pub premier_match_info: serde_json::Map<String, serde_json::Value>,
     }
-    /// Player data object.
+    /// `val-match-v1.PlayerDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Player {
         #[serde(rename = "puuid")]
@@ -4419,7 +4418,7 @@ pub mod val_match_v1 {
         #[serde(rename = "characterId")]
         pub character_id: String,
         #[serde(rename = "stats")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub stats: Option<PlayerStats>,
         #[serde(rename = "competitiveTier")]
         pub competitive_tier: i32,
@@ -4432,9 +4431,9 @@ pub mod val_match_v1 {
         #[serde(rename = "accountLevel")]
         pub account_level: i32,
     }
-    /// PlayerStats data object.
+    /// `val-match-v1.PlayerStatsDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlayerStats {
         #[serde(rename = "score")]
@@ -4450,12 +4449,12 @@ pub mod val_match_v1 {
         #[serde(rename = "playtimeMillis")]
         pub playtime_millis: i32,
         #[serde(rename = "abilityCasts")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub ability_casts: Option<AbilityCasts>,
     }
-    /// AbilityCasts data object.
+    /// `val-match-v1.AbilityCastsDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct AbilityCasts {
         #[serde(rename = "grenadeCasts")]
@@ -4467,9 +4466,9 @@ pub mod val_match_v1 {
         #[serde(rename = "ultimateCasts")]
         pub ultimate_casts: i32,
     }
-    /// Coach data object.
+    /// `val-match-v1.CoachDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Coach {
         #[serde(rename = "puuid")]
@@ -4477,9 +4476,9 @@ pub mod val_match_v1 {
         #[serde(rename = "teamId")]
         pub team_id: String,
     }
-    /// Team data object.
+    /// `val-match-v1.TeamDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Team {
         /// This is an arbitrary string. Red and Blue in bomb modes. The puuid of the player in deathmatch.
@@ -4495,9 +4494,9 @@ pub mod val_match_v1 {
         #[serde(rename = "numPoints")]
         pub num_points: i32,
     }
-    /// RoundResult data object.
+    /// `val-match-v1.RoundResultDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct RoundResult {
         #[serde(rename = "roundNum")]
@@ -4510,16 +4509,16 @@ pub mod val_match_v1 {
         pub winning_team: String,
         /// PUUID of player
         #[serde(rename = "bombPlanter")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub bomb_planter: Option<String>,
         /// PUUID of player
         #[serde(rename = "bombDefuser")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub bomb_defuser: Option<String>,
         #[serde(rename = "plantRoundTime")]
         pub plant_round_time: i32,
         #[serde(rename = "plantPlayerLocations")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub plant_player_locations: Option<std::vec::Vec<PlayerLocations>>,
         #[serde(rename = "plantLocation")]
         pub plant_location: Location,
@@ -4528,7 +4527,7 @@ pub mod val_match_v1 {
         #[serde(rename = "defuseRoundTime")]
         pub defuse_round_time: i32,
         #[serde(rename = "defusePlayerLocations")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub defuse_player_locations: Option<std::vec::Vec<PlayerLocations>>,
         #[serde(rename = "defuseLocation")]
         pub defuse_location: Location,
@@ -4539,9 +4538,9 @@ pub mod val_match_v1 {
         #[serde(rename = "winningTeamRole")]
         pub winning_team_role: String,
     }
-    /// PlayerLocations data object.
+    /// `val-match-v1.PlayerLocationsDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlayerLocations {
         #[serde(rename = "puuid")]
@@ -4551,9 +4550,9 @@ pub mod val_match_v1 {
         #[serde(rename = "location")]
         pub location: Location,
     }
-    /// Location data object.
+    /// `val-match-v1.LocationDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Location {
         #[serde(rename = "x")]
@@ -4561,9 +4560,9 @@ pub mod val_match_v1 {
         #[serde(rename = "y")]
         pub y: i32,
     }
-    /// PlayerRoundStats data object.
+    /// `val-match-v1.PlayerRoundStatsDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlayerRoundStats {
         #[serde(rename = "puuid")]
@@ -4579,9 +4578,9 @@ pub mod val_match_v1 {
         #[serde(rename = "ability")]
         pub ability: Ability,
     }
-    /// Kill data object.
+    /// `val-match-v1.KillDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Kill {
         #[serde(rename = "timeSinceGameStartMillis")]
@@ -4604,9 +4603,9 @@ pub mod val_match_v1 {
         #[serde(rename = "finishingDamage")]
         pub finishing_damage: FinishingDamage,
     }
-    /// FinishingDamage data object.
+    /// `val-match-v1.FinishingDamageDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct FinishingDamage {
         #[serde(rename = "damageType")]
@@ -4616,9 +4615,9 @@ pub mod val_match_v1 {
         #[serde(rename = "isSecondaryFireMode")]
         pub is_secondary_fire_mode: bool,
     }
-    /// Damage data object.
+    /// `val-match-v1.DamageDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Damage {
         /// PUUID
@@ -4633,9 +4632,9 @@ pub mod val_match_v1 {
         #[serde(rename = "headshots")]
         pub headshots: i32,
     }
-    /// Economy data object.
+    /// `val-match-v1.EconomyDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Economy {
         #[serde(rename = "loadoutValue")]
@@ -4649,27 +4648,27 @@ pub mod val_match_v1 {
         #[serde(rename = "spent")]
         pub spent: i32,
     }
-    /// Ability data object.
+    /// `val-match-v1.AbilityDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Ability {
         #[serde(rename = "grenadeEffects")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub grenade_effects: Option<String>,
         #[serde(rename = "ability1Effects")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub ability1_effects: Option<String>,
         #[serde(rename = "ability2Effects")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub ability2_effects: Option<String>,
         #[serde(rename = "ultimateEffects")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub ultimate_effects: Option<String>,
     }
-    /// Matchlist data object.
+    /// `val-match-v1.MatchlistDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Matchlist {
         #[serde(rename = "puuid")]
@@ -4677,9 +4676,9 @@ pub mod val_match_v1 {
         #[serde(rename = "history")]
         pub history: std::vec::Vec<MatchlistEntry>,
     }
-    /// MatchlistEntry data object.
+    /// `val-match-v1.MatchlistEntryDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct MatchlistEntry {
         #[serde(rename = "matchId")]
@@ -4689,9 +4688,9 @@ pub mod val_match_v1 {
         #[serde(rename = "queueId")]
         pub queue_id: String,
     }
-    /// RecentMatches data object.
+    /// `val-match-v1.RecentMatchesDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct RecentMatches {
         #[serde(rename = "currentTime")]
@@ -4703,13 +4702,13 @@ pub mod val_match_v1 {
 }
 
 /// Data structs used by [`ValRankedV1`](crate::endpoints::ValRankedV1).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod val_ranked_v1 {
-    /// Leaderboard data object.
+    /// `val-ranked-v1.LeaderboardDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Leaderboard {
         /// The shard for the given leaderboard.
@@ -4724,40 +4723,40 @@ pub mod val_ranked_v1 {
         #[serde(rename = "players")]
         pub players: std::vec::Vec<Player>,
         #[serde(rename = "immortalStartingPage")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub immortal_starting_page: Option<i64>,
         #[serde(rename = "immortalStartingIndex")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub immortal_starting_index: Option<i64>,
         #[serde(rename = "topTierRRThreshold")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub top_tier_rr_threshold: Option<i64>,
         #[serde(rename = "tierDetails")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub tier_details: Option<std::collections::HashMap<i64, TierDetail>>,
         #[serde(rename = "startIndex")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub start_index: Option<i64>,
         #[serde(rename = "query")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub query: Option<String>,
     }
-    /// Player data object.
+    /// `val-ranked-v1.PlayerDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Player {
         /// This field may be omitted if the player has been anonymized.
         #[serde(rename = "puuid")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub puuid: Option<String>,
         /// This field may be omitted if the player has been anonymized.
         #[serde(rename = "gameName")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub game_name: Option<String>,
         /// This field may be omitted if the player has been anonymized.
         #[serde(rename = "tagLine")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub tag_line: Option<String>,
         #[serde(rename = "leaderboardRank")]
         pub leaderboard_rank: i64,
@@ -4766,12 +4765,12 @@ pub mod val_ranked_v1 {
         #[serde(rename = "numberOfWins")]
         pub number_of_wins: i64,
         #[serde(rename = "competitiveTier")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub competitive_tier: Option<i64>,
     }
-    /// TierDetail data object.
+    /// `val-ranked-v1.TierDetailDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct TierDetail {
         #[serde(rename = "rankedRatingThreshold")]
@@ -4784,13 +4783,13 @@ pub mod val_ranked_v1 {
 }
 
 /// Data structs used by [`ValStatusV1`](crate::endpoints::ValStatusV1).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod val_status_v1 {
-    /// PlatformData data object.
+    /// `val-status-v1.PlatformDataDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct PlatformData {
         #[serde(rename = "id")]
@@ -4804,9 +4803,9 @@ pub mod val_status_v1 {
         #[serde(rename = "incidents")]
         pub incidents: std::vec::Vec<Status>,
     }
-    /// Status data object.
+    /// `val-status-v1.StatusDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Status {
         #[serde(rename = "id")]
@@ -4831,9 +4830,9 @@ pub mod val_status_v1 {
         #[serde(rename = "platforms")]
         pub platforms: std::vec::Vec<String>,
     }
-    /// Content data object.
+    /// `val-status-v1.ContentDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Content {
         #[serde(rename = "locale")]
@@ -4841,9 +4840,9 @@ pub mod val_status_v1 {
         #[serde(rename = "content")]
         pub content: String,
     }
-    /// Update data object.
+    /// `val-status-v1.UpdateDto` data object.
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct Update {
         #[serde(rename = "id")]

--- a/riven/src/models.rs
+++ b/riven/src/models.rs
@@ -4398,6 +4398,7 @@ pub mod val_match_v1 {
         #[serde(rename = "region")]
         pub region: String,
         #[serde(rename = "premierMatchInfo")]
+        #[eserde(compat)]
         pub premier_match_info: serde_json::Map<String, serde_json::Value>,
     }
     /// Player data object.

--- a/riven/src/req/regional_requester.rs
+++ b/riven/src/req/regional_requester.rs
@@ -35,6 +35,7 @@ impl RegionalRequester {
         request: RequestBuilder,
     ) -> Result<ResponseInfo> {
         let mut retries: u8 = 0;
+        let mut reqwest_errors = Vec::new();
         loop {
             let method_rate_limit = self
                 .method_rate_limits
@@ -58,15 +59,19 @@ impl RegionalRequester {
                 Ok(response) => response,
                 // Check for lower level errors, like connection errors.
                 Err(e) => {
+                    reqwest_errors.push(e);
                     if retries >= config.retries {
                         log::debug!(
                             "Request failed (retried {} times), failure, returning error.",
                             retries
                         );
-                        break Err(RiotApiError::new(e, retries, None, None));
+                        break Err(RiotApiError::new(reqwest_errors, None, retries, None, None));
                     }
                     let delay = Duration::from_secs(2_u64.pow(retries as u32));
-                    log::debug!("Request failed with cause \"{}\", (retried {} times), using exponential backoff, retrying after {:?}.", e.to_string(), retries, delay);
+                    log::debug!(
+                        "Request failed with cause \"{}\", (retried {} times), using exponential backoff, retrying after {:?}.",
+                        reqwest_errors.last().unwrap().to_string(), retries, delay,
+                    );
                     let backoff = sleep(delay);
                     #[cfg(feature = "tracing")]
                     let backoff = backoff.instrument(tracing::info_span!("backoff"));
@@ -95,14 +100,16 @@ impl RegionalRequester {
                     response,
                     retries,
                     status_none,
+                    reqwest_errors,
                 });
             }
-            let err = response.error_for_status_ref().err().unwrap_or_else(|| {
+            reqwest_errors.push(response.error_for_status_ref().err().unwrap_or_else(|| {
                 panic!(
                     "Unhandlable response status code, neither success nor failure: {}.",
                     status
                 )
-            });
+            }));
+
             // Failure, may or may not be retryable.
             // Not-retryable: no more retries or 4xx or ? (3xx, redirects exceeded).
             // Retryable: retries remaining, and 429 or 5xx.
@@ -115,7 +122,8 @@ impl RegionalRequester {
                     retries
                 );
                 break Err(RiotApiError::new(
-                    err,
+                    reqwest_errors,
+                    None,
                     retries,
                     Some(response),
                     Some(status),

--- a/riven/src/response_info.rs
+++ b/riven/src/response_info.rs
@@ -1,7 +1,9 @@
 use reqwest::Response;
 
+#[cfg(not(feature = "eserde"))]
+use serde::de::Deserialize;
 #[cfg(feature = "eserde")]
-use eserde::json as serde_json;
+use eserde::{EDeserialize as Deserialize, json as serde_json};
 
 use crate::{Result, RiotApiError};
 
@@ -20,7 +22,7 @@ pub struct ResponseInfo {
 
 impl ResponseInfo {
     /// Helper to deserialize the JSON-encoded value from a `ResponseInfo`, properly handling errors.
-    pub(crate) async fn json<T: serde::de::DeserializeOwned>(self) -> Result<T> {
+    pub(crate) async fn json<T: for<'de> Deserialize<'de>>(self) -> Result<T> {
         let Self {
             response,
             retries,

--- a/riven/src/response_info.rs
+++ b/riven/src/response_info.rs
@@ -1,10 +1,5 @@
 use reqwest::Response;
 
-#[cfg(not(feature = "eserde"))]
-use serde::de::Deserialize;
-#[cfg(feature = "eserde")]
-use eserde::{EDeserialize as Deserialize, json as serde_json};
-
 use crate::{Result, RiotApiError};
 
 /// A "raw" unparsed successful response from the Riot API, for internal or advanced use cases.
@@ -22,7 +17,7 @@ pub struct ResponseInfo {
 
 impl ResponseInfo {
     /// Helper to deserialize the JSON-encoded value from a `ResponseInfo`, properly handling errors.
-    pub(crate) async fn json<T: for<'de> Deserialize<'de>>(self) -> Result<T> {
+    pub(crate) async fn json<T: for<'de> crate::de::Deserialize<'de>>(self) -> Result<T> {
         let Self {
             response,
             retries,
@@ -43,7 +38,7 @@ impl ResponseInfo {
                 ));
             }
         };
-        let value = match serde_json::from_slice::<T>(&bytes) {
+        let value = match crate::de::from_slice::<T>(&bytes) {
             Ok(value) => value,
             Err(serde_err) => {
                 return Err(RiotApiError::new(

--- a/riven/src/response_info.rs
+++ b/riven/src/response_info.rs
@@ -1,5 +1,8 @@
 use reqwest::Response;
 
+#[cfg(feature = "eserde")]
+use eserde::json as serde_json;
+
 use crate::{Result, RiotApiError};
 
 /// A "raw" unparsed successful response from the Riot API, for internal or advanced use cases.

--- a/riven/src/response_info.rs
+++ b/riven/src/response_info.rs
@@ -1,6 +1,9 @@
 use reqwest::Response;
 
+use crate::{Result, RiotApiError};
+
 /// A "raw" unparsed successful response from the Riot API, for internal or advanced use cases.
+#[non_exhaustive]
 pub struct ResponseInfo {
     /// The reqwest response.
     pub response: Response,
@@ -8,4 +11,45 @@ pub struct ResponseInfo {
     pub retries: u8,
     /// If the response has an HTTP status code indicating a `None` response (i.e. 204, 404).
     pub status_none: bool,
+    /// Any reqwest errors that occurred. A response may still be successful even if this is non-empty due to retrying.
+    pub reqwest_errors: Vec<reqwest::Error>,
+}
+
+impl ResponseInfo {
+    /// Helper to deserialize the JSON-encoded value from a `ResponseInfo`, properly handling errors.
+    pub(crate) async fn json<T: serde::de::DeserializeOwned>(self) -> Result<T> {
+        let Self {
+            response,
+            retries,
+            status_none: _,
+            mut reqwest_errors,
+        } = self;
+        let status = response.status();
+        let bytes = match response.bytes().await {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                reqwest_errors.push(err);
+                return Err(RiotApiError::new(
+                    reqwest_errors,
+                    None,
+                    retries,
+                    None, // `.bytes()` consumes the response.
+                    Some(status),
+                ));
+            }
+        };
+        let value = match serde_json::from_slice::<T>(&bytes) {
+            Ok(value) => value,
+            Err(serde_err) => {
+                return Err(RiotApiError::new(
+                    reqwest_errors,
+                    Some(serde_err),
+                    retries,
+                    None, // `.bytes()` consumes the response.
+                    Some(status),
+                ));
+            }
+        };
+        Ok(value)
+    }
 }

--- a/riven/src/riot_api.rs
+++ b/riven/src/riot_api.rs
@@ -99,10 +99,7 @@ impl RiotApi {
         let rinfo = self
             .execute_raw(method_id, region_platform, request)
             .await?;
-        let retries = rinfo.retries;
-        let status = rinfo.response.status();
-        let value = rinfo.response.json::<T>().await;
-        value.map_err(|e| RiotApiError::new(e, retries, None, Some(status)))
+        rinfo.json::<T>().await
     }
 
     /// This method should generally not be used directly. Consider using endpoint wrappers instead.
@@ -128,10 +125,7 @@ impl RiotApi {
         if rinfo.status_none {
             return Ok(None);
         }
-        let retries = rinfo.retries;
-        let status = rinfo.response.status();
-        let value = rinfo.response.json::<Option<T>>().await;
-        value.map_err(|e| RiotApiError::new(e, retries, None, Some(status)))
+        rinfo.json::<Option<T>>().await
     }
 
     /// This method should generally not be used directly. Consider using endpoint wrappers instead.
@@ -156,11 +150,17 @@ impl RiotApi {
             .await?;
         let retries = rinfo.retries;
         let status = rinfo.response.status();
-        rinfo
-            .response
-            .error_for_status()
-            .map(|_| ())
-            .map_err(|e| RiotApiError::new(e, retries, None, Some(status)))
+        if status.is_client_error() || status.is_server_error() {
+            Err(RiotApiError::new(
+                rinfo.reqwest_errors,
+                None,
+                retries,
+                Some(rinfo.response),
+                Some(status),
+            ))
+        } else {
+            Ok(())
+        }
     }
 
     /// This method should generally not be used directly. Consider using endpoint wrappers instead.

--- a/riven/src/riot_api.rs
+++ b/riven/src/riot_api.rs
@@ -90,7 +90,7 @@ impl RiotApi {
     ///
     /// # Returns
     /// A future resolving to a `Result` containg either a `T` (success) or a `RiotApiError` (failure).
-    pub async fn execute_val<'a, T: serde::de::DeserializeOwned + 'a>(
+    pub async fn execute_val<'a, T: for<'de> crate::Deserialize<'de> + 'a>(
         &'a self,
         method_id: &'static str,
         region_platform: &'static str,
@@ -113,7 +113,7 @@ impl RiotApi {
     ///
     /// # Returns
     /// A future resolving to a `Result` containg either an `Option<T>` (success) or a `RiotApiError` (failure).
-    pub async fn execute_opt<'a, T: serde::de::DeserializeOwned + 'a>(
+    pub async fn execute_opt<'a, T: for<'de> crate::Deserialize<'de> + 'a>(
         &'a self,
         method_id: &'static str,
         region_platform: &'static str,

--- a/riven/src/riot_api.rs
+++ b/riven/src/riot_api.rs
@@ -90,7 +90,7 @@ impl RiotApi {
     ///
     /// # Returns
     /// A future resolving to a `Result` containg either a `T` (success) or a `RiotApiError` (failure).
-    pub async fn execute_val<'a, T: for<'de> crate::Deserialize<'de> + 'a>(
+    pub async fn execute_val<'a, T: for<'de> crate::de::Deserialize<'de> + 'a>(
         &'a self,
         method_id: &'static str,
         region_platform: &'static str,
@@ -113,7 +113,7 @@ impl RiotApi {
     ///
     /// # Returns
     /// A future resolving to a `Result` containg either an `Option<T>` (success) or a `RiotApiError` (failure).
-    pub async fn execute_opt<'a, T: for<'de> crate::Deserialize<'de> + 'a>(
+    pub async fn execute_opt<'a, T: for<'de> crate::de::Deserialize<'de> + 'a>(
         &'a self,
         method_id: &'static str,
         region_platform: &'static str,

--- a/riven/srcgen/consts/game_type.rs.dt
+++ b/riven/srcgen/consts/game_type.rs.dt
@@ -3,14 +3,13 @@
     const gameTypes = require('./.gameTypes.json');
 }}{{= dotUtils.preamble() }}
 
-use serde::{ Serialize, Deserialize };
 use strum_macros::{ EnumString, Display, AsRefStr, IntoStaticStr };
 
 /// League of Legends game type: matched game, custom game, or tutorial game.
 #[derive(Debug, Copy, Clone)]
 #[derive(Eq, PartialEq, Hash)]
 #[derive(EnumString, Display, AsRefStr, IntoStaticStr)]
-#[derive(Serialize, Deserialize)]
+#[derive(crate::Serialize, crate::Deserialize)]
 #[repr(u8)]
 pub enum GameType {
 {{

--- a/riven/srcgen/consts/game_type.rs.dt
+++ b/riven/srcgen/consts/game_type.rs.dt
@@ -9,7 +9,7 @@ use strum_macros::{ EnumString, Display, AsRefStr, IntoStaticStr };
 #[derive(Debug, Copy, Clone)]
 #[derive(Eq, PartialEq, Hash)]
 #[derive(EnumString, Display, AsRefStr, IntoStaticStr)]
-#[derive(crate::Serialize, crate::Deserialize)]
+#[derive(serde::Serialize, crate::de::Deserialize)]
 #[repr(u8)]
 pub enum GameType {
 {{

--- a/riven/srcgen/consts/route.rs.dt
+++ b/riven/srcgen/consts/route.rs.dt
@@ -171,7 +171,7 @@ pub enum ValPlatformRoute {
 #[derive(PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[derive(IntoPrimitive, TryFromPrimitive)]
 #[derive(EnumString, EnumIter, Display, IntoStaticStr)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(crate::Serialize, crate::Deserialize)]
 #[derive(Clone, Copy)]
 #[repr(u8)]
 #[non_exhaustive]

--- a/riven/srcgen/consts/route.rs.dt
+++ b/riven/srcgen/consts/route.rs.dt
@@ -2,6 +2,7 @@
     const dotUtils = require('./dotUtils.js');
     const routesTable = require('./.routesTable.json');
 }}{{= dotUtils.preamble() }}
+#![allow(clippy::upper_case_acronyms)]
 
 use num_enum::{ IntoPrimitive, TryFromPrimitive };
 use strum_macros::{ EnumString, EnumIter, Display, IntoStaticStr };

--- a/riven/srcgen/consts/route.rs.dt
+++ b/riven/srcgen/consts/route.rs.dt
@@ -171,7 +171,7 @@ pub enum ValPlatformRoute {
 #[derive(PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[derive(IntoPrimitive, TryFromPrimitive)]
 #[derive(EnumString, EnumIter, Display, IntoStaticStr)]
-#[derive(crate::Serialize, crate::Deserialize)]
+#[derive(serde::Serialize, crate::de::Deserialize)]
 #[derive(Clone, Copy)]
 #[repr(u8)]
 #[non_exhaustive]

--- a/riven/srcgen/endpoints.rs.dt
+++ b/riven/srcgen/endpoints.rs.dt
@@ -200,6 +200,7 @@ impl<'a> {{= endpoint }}<'a> {
 {{~}}
 {{? bodyType }}
         let request = request.body(serde_json::ser::to_vec(body).unwrap());
+        req.headers_mut().insert(reqwest::header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
 {{?}}
         let future = self.base.execute{{= hasReturn ? (returnOptional ? '_opt' : '_val') : '' }}{{= returnTypeTurbofish }}("{{= operationId }}", route_str, request);
         #[cfg(feature = "tracing")]

--- a/riven/srcgen/endpoints.rs.dt
+++ b/riven/srcgen/endpoints.rs.dt
@@ -199,8 +199,9 @@ impl<'a> {{= endpoint }}<'a> {
         {{= dotUtils.formatAddHeaderParam(headerParam) }}
 {{~}}
 {{? bodyType }}
-        let request = request.body(serde_json::ser::to_vec(body).unwrap());
-        req.headers_mut().insert(reqwest::header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        let request = request
+            .body(serde_json::ser::to_vec(body).unwrap())
+            .header(reqwest::header::CONTENT_TYPE, "application/json");
 {{?}}
         let future = self.base.execute{{= hasReturn ? (returnOptional ? '_opt' : '_val') : '' }}{{= returnTypeTurbofish }}("{{= operationId }}", route_str, request);
         #[cfg(feature = "tracing")]

--- a/riven/srcgen/lib.rs.dt
+++ b/riven/srcgen/lib.rs.dt
@@ -11,10 +11,10 @@
 {{~}}
 
 pub use serde::Serialize;
-#[cfg(feature = "eserde")]
-pub use eserde::Deserialize;
 #[cfg(not(feature = "eserde"))]
-pub use serde::de::Deserialize;
+pub use serde::{Deserialize, de::Deserialize};
+#[cfg(feature = "eserde")]
+pub use eserde::{Deserialize, EDeserialize as Deserialize};
 
 // Re-exported reqwest types.
 pub use reqwest;

--- a/riven/srcgen/lib.rs.dt
+++ b/riven/srcgen/lib.rs.dt
@@ -10,6 +10,12 @@
 //!{{= line ? (' ' + line) : '' }}
 {{~}}
 
+pub use serde::Serialize;
+#[cfg(feature = "eserde")]
+pub use eserde::Deserialize;
+#[cfg(not(feature = "eserde"))]
+pub use serde::de::Deserialize;
+
 // Re-exported reqwest types.
 pub use reqwest;
 

--- a/riven/srcgen/lib.rs.dt
+++ b/riven/srcgen/lib.rs.dt
@@ -10,14 +10,12 @@
 //!{{= line ? (' ' + line) : '' }}
 {{~}}
 
-pub use serde::Serialize;
-#[cfg(not(feature = "eserde"))]
-pub use serde::{Deserialize, de::Deserialize};
-#[cfg(feature = "eserde")]
-pub use eserde::{Deserialize, EDeserialize as Deserialize};
-
-// Re-exported reqwest types.
+// Re-exported crates.
 pub use reqwest;
+pub use serde;
+#[cfg(feature = "eserde")]
+pub use eserde;
+
 
 mod config;
 pub use config::RiotApiConfig;
@@ -61,4 +59,18 @@ pub mod time {
     pub use tokio::time::sleep;
     #[cfg(target_family = "wasm")]
     pub use gloo_timers::future::sleep;
+}
+
+/// Deserialization utilities from either `serde_json` or `eserde`.
+#[rustfmt::skip]
+pub mod de {
+    #[cfg(not(feature = "eserde"))]
+    pub use serde::Deserialize;
+    #[cfg(not(feature = "eserde"))]
+    pub use serde_json::{Error, from_str, from_slice};
+
+    #[cfg(feature = "eserde")]
+    pub use eserde::{Deserialize, EDeserialize as Deserialize, DeserializationErrors as Error};
+    #[cfg(feature = "eserde")]
+    pub use eserde::json::{from_str, from_slice};
 }

--- a/riven/srcgen/models.rs.dt
+++ b/riven/srcgen/models.rs.dt
@@ -25,7 +25,7 @@
         const endpoint_pascal_case = dotUtils.changeCase.pascalCase(endpoint);
 }}
 /// Data structs used by [`{{= endpoint_pascal_case }}`](crate::endpoints::{{= endpoint_pascal_case }}).
-/// 
+///
 /// Note: this module is automatically generated.
 #[allow(dead_code)]
 pub mod {{= dotUtils.changeCase.snakeCase(endpoint) }} {
@@ -37,7 +37,7 @@ pub mod {{= dotUtils.changeCase.snakeCase(endpoint) }} {
             const props = schema.properties;
             const requiredSet = new Set(schema.required);
 }}
-    /// {{= schemaName }} data object.
+    /// `{{= endpoint }}.{{= rawSchemaName }}` data object.
 {{? schema.description }}
     /// # Description
     /// {{= schema.description.split('\n').map(x => x.trim()).join('<br>\r\n    /// ') }}
@@ -45,7 +45,7 @@ pub mod {{= dotUtils.changeCase.snakeCase(endpoint) }} {
     /// Note: This struct is automatically generated
 {{?}}
     #[derive(Clone, Debug)]
-    #[derive(crate::Serialize, crate::Deserialize)]
+    #[derive(serde::Serialize, crate::de::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct {{= schemaName }} {
 {{
@@ -65,7 +65,7 @@ pub mod {{= dotUtils.changeCase.snakeCase(endpoint) }} {
 {{?}}
         {{= dotUtils.formatJsonProperty(propKey, prop) }}
 {{? optional }}
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
 {{?}}
 {{? 'championId' === propKey && (prop.description || '').includes('this field returned invalid championIds') }}
         ///

--- a/riven/srcgen/models.rs.dt
+++ b/riven/srcgen/models.rs.dt
@@ -45,7 +45,7 @@ pub mod {{= dotUtils.changeCase.snakeCase(endpoint) }} {
     /// Note: This struct is automatically generated
 {{?}}
     #[derive(Clone, Debug)]
-    #[derive(serde::Serialize, serde::Deserialize)]
+    #[derive(crate::Serialize, crate::Deserialize)]
     #[cfg_attr(feature = "deny-unknown-fields", serde(deny_unknown_fields))]
     pub struct {{= schemaName }} {
 {{

--- a/riven/tests/testutils.rs
+++ b/riven/tests/testutils.rs
@@ -178,7 +178,7 @@ pub async fn tft_match_v1_get(
         let p = riot_api().tft_match_v1().get_match(route, matche);
         let m = p
             .await
-            .map_err(|e| format!("Failed to get tft match {}: {:?}", matche, e))?
+            .map_err(|e| format!("Failed to get tft match {}: {}", matche, e))?
             .ok_or(format!("Match {} not found.", matche))?;
 
         if matche != &*m.metadata.match_id {
@@ -219,7 +219,7 @@ pub async fn match_v5_get(
         let p = riot_api().match_v5().get_match(route, matche);
         let m = p
             .await
-            .map_err(|e| format!("Failed to get match {}: {:?}", matche, e))?
+            .map_err(|e| format!("Failed to get match {}: {}", matche, e))?
             .ok_or(format!("Match {} not found.", matche))?;
 
         if matche != &*m.metadata.match_id {
@@ -279,7 +279,7 @@ pub async fn match_v5_get_timeline(
         let p = riot_api().match_v5().get_timeline(route, matche);
         let m = p
             .await
-            .map_err(|e| format!("Failed to get match timeline {}: {:?}", matche, e))?
+            .map_err(|e| format!("Failed to get match timeline {}: {}", matche, e))?
             .ok_or(format!("Match {} not found.", matche))?;
         if matche != &*m.metadata.match_id {
             return Err(format!(
@@ -474,7 +474,7 @@ pub async fn val_match_v1_get(
         let p = riot_api().val_match_v1().get_match(route, matche);
         let m = p
             .await
-            .map_err(|e| format!("Failed to get val match {}: {:?}", matche, e))?
+            .map_err(|e| format!("Failed to get val match {}: {}", matche, e))?
             .ok_or(format!("Match {} not found.", matche))?;
 
         // TODO(mingwei): Check the match a bit.

--- a/test-full.bash
+++ b/test-full.bash
@@ -7,7 +7,7 @@ cargo +stable check --all-targets --features metrics,tracing,__proxy
 
 # Ensure nightly builds.
 cargo check --all-targets --features nightly,metrics,tracing,__proxy
-cargo build --all-targets --features nightly,deny-unknown,__proxy
+cargo build --all-targets --features nightly,deny-unknown,eserde,__proxy
 
 # Run nightly tests.
 bash test.bash

--- a/test-wasm.bash
+++ b/test-wasm.bash
@@ -9,4 +9,4 @@ cd riven
 wasm-pack build -- --features nightly,tracing,metrics
 
 # Run tests.
-wasm-pack test --node -- --features nightly,deny-unknown
+wasm-pack test --node -- --features nightly,deny-unknown,eserde

--- a/test.bash
+++ b/test.bash
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euxo pipefail
 
-RGAPI_KEY="$(cat apikey.txt)" RUST_BACKTRACE=full RUST_LOG=riven=debug cargo test --no-fail-fast --features nightly,tracing,deny-unknown -- --nocapture
+RGAPI_KEY="$(cat apikey.txt)" RUST_BACKTRACE=full RUST_LOG=riven=debug cargo test --no-fail-fast --features nightly,tracing,eserde,deny-unknown,eserde -- --nocapture


### PR DESCRIPTION
Using [`eserde`](https://github.com/mainmatter/eserde) at least for testing makes it much, much easier to find all the schema changes Riot makes every other Wednesday, and therefore makes this and https://github.com/MingweiSamuel/riotapi-schema easier to maintain.

Example of error output:
```rust
Failed to get match JP1_498473890: Riot API request failed after 0 retries with status code Some(200).
Deserialization error: Something went wrong during deserialization:
- info.participants[0].PlayerScore2: invalid type: floating point `732.5479125976562`, expected i32 at line 1 column 1795
- info.participants[0].PlayerScore3: invalid type: floating point `0.3532763719558716`, expected i32 at line 1 column 1829
- info.participants[0].PlayerScore4: invalid type: floating point `-0.8999999761581421`, expected i32 at line 1 column 1864
- info.participants[0].PlayerScore5: invalid type: floating point `1428.712158203125`, expected i32 at line 1 column 1897
- info.participants[0].PlayerScore6: invalid type: floating point `3546.9150390625`, expected i32 at line 1 column 1928
- info.participants[0].PlayerScore7: invalid type: floating point `848.3316650390625`, expected i32 at line 1 column 1961
- info.participants[0].PlayerScore8: invalid type: floating point `23.0013484954834`, expected i32 at line 1 column 1993
- info.participants[0].missions.playerScore2: invalid type: floating point `732.5479125976562`, expected i32 at line 1 column 6427
- info.participants[0].missions.playerScore3: invalid type: floating point `0.3532763719558716`, expected i32 at line 1 column 6461
- info.participants[0].missions.playerScore4: invalid type: floating point `-0.8999999761581421`, expected i32 at line 1 column 6496
- info.participants[0].missions.playerScore5: invalid type: floating point `1428.712158203125`, expected i32 at line 1 column 6529
- info.participants[0].missions.playerScore6: invalid type: floating point `3546.9150390625`, expected i32 at line 1 column 6560
- info.participants[0].missions.playerScore7: invalid type: floating point `848.3316650390625`, expected i32 at line 1 column 6593
- info.participants[0].missions.playerScore8: invalid type: floating point `23.0013484954834`, expected i32 at line 1 column 6625
```